### PR TITLE
change google-cloud-resourcemanager dependency from compile to implementation

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -2,5 +2,5 @@ dependencies {
     implementation 'io.opencensus:opencensus-api:0.26.0'
     implementation 'io.opencensus:opencensus-impl:0.26.0'
 
-    testCompileOnly 'com.google.cloud:google-cloud-resourcemanager:0.117.2-alpha'
+    testImplementation 'com.google.cloud:google-cloud-resourcemanager:0.117.2-alpha'
 }


### PR DESCRIPTION
Compile is deprated and should be replaced by implements:

https://stackoverflow.com/questions/44493378/whats-the-difference-between-implementation-and-compile-in-gradle/44493811
And that is why  OperationAnnotatorTest is not working well with compile
