### PR TITLE
CA-868 Add cleanup recording for creating blobs in google storage.

### DIFF
--- a/common/src/main/resources/cloud_resources_uid.yaml
+++ b/common/src/main/resources/cloud_resources_uid.yaml
@@ -10,6 +10,20 @@ paths: {}
 
 components:
   schemas:
+    GoogleBlobUid:
+      type: object
+      required:
+        - resourceType
+        - bucketName
+        - blobName
+      properties:
+        resourceType:
+          type: string
+          default: googleBlobUid
+        bucketName:
+          type: string
+        blobName:
+          type: string
     GoogleBucketUid:
       type: object
       required:
@@ -34,6 +48,7 @@ components:
           type: string
     CloudResourceUid:
       oneOf:
+      - $ref: '#/components/schemas/GoogleBlobUid'
       - $ref: '#/components/schemas/GoogleBucketUid'
       - $ref: '#/components/schemas/GoogleProjectUid'
       discriminator:
@@ -42,5 +57,6 @@ components:
         mapping:
           # Mapping should match the default resourceType values. Default resourceType values allow created Java objects
           # to have the same value as created -> serialized -> deserialized values.
+          googleBlobUid: '#/components/schemas/GoogleBlobUid'
           googleBucketUid: '#/components/schemas/GoogleBucketUid'
           googleProjectUid: '#/components/schemas/GoogleProjectUid'

--- a/common/src/test/java/bio/terra/cloudres/resources/CloudResourceUidTest.java
+++ b/common/src/test/java/bio/terra/cloudres/resources/CloudResourceUidTest.java
@@ -29,6 +29,12 @@ public class CloudResourceUidTest {
   }
 
   @Test
+  public void googleBlob() throws Exception {
+    GoogleBlobUid blob = new GoogleBlobUid().bucketName("my-bucket").blobName("my-blob");
+    assertSerializationIdempotency(blob, GoogleBlobUid.class);
+  }
+
+  @Test
   public void googleBucket() throws Exception {
     GoogleBucketUid bucket = new GoogleBucketUid().bucketName("my-bucket");
     assertSerializationIdempotency(bucket, GoogleBucketUid.class);

--- a/google-storage/src/main/java/bio/terra/cloudres/google/storage/SerializeUtils.java
+++ b/google-storage/src/main/java/bio/terra/cloudres/google/storage/SerializeUtils.java
@@ -1,5 +1,6 @@
 package bio.terra.cloudres.google.storage;
 
+import bio.terra.cloudres.resources.GoogleBlobUid;
 import com.google.cloud.storage.Acl;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -11,6 +12,10 @@ import java.lang.reflect.Type;
 /** Utils for serializing {@link com.google.cloud.storage} objects. */
 class SerializeUtils {
   private SerializeUtils() {}
+
+  static GoogleBlobUid create(BlobId blobId) {
+    return new GoogleBlobUid().blobName(blobId.getName()).bucketName(blobId.getBucket());
+  }
 
   static JsonObject convert(Acl acl) {
     return convertWithGson(acl, Acl.class);

--- a/google-storage/src/main/java/bio/terra/cloudres/google/storage/StorageCow.java
+++ b/google-storage/src/main/java/bio/terra/cloudres/google/storage/StorageCow.java
@@ -31,6 +31,8 @@ public class StorageCow {
 
   /** See {@link Storage#create(BlobInfo, Storage.BlobTargetOption...)}. */
   public BlobCow create(BlobInfo blobInfo) {
+    CleanupRecorder.record(
+        SerializeUtils.create(blobInfo.getBlobId()), clientConfig.getCleanupConfig());
     Blob blob =
         operationAnnotator.executeCowOperation(
             CloudOperation.GOOGLE_CREATE_BLOB,
@@ -131,6 +133,8 @@ public class StorageCow {
 
   /** See {@link Storage#writer(BlobInfo, Storage.BlobWriteOption...)} */
   public WriteChannel writer(BlobInfo blobInfo) {
+    CleanupRecorder.record(
+        SerializeUtils.create(blobInfo.getBlobId()), clientConfig.getCleanupConfig());
     return operationAnnotator.executeCowOperation(
         CloudOperation.GOOGLE_CREATE_BLOB_AND_WRITER,
         () -> storage.writer(blobInfo),

--- a/google-storage/src/test/java/bio/terra/cloudres/google/storage/BlobCowTest.java
+++ b/google-storage/src/test/java/bio/terra/cloudres/google/storage/BlobCowTest.java
@@ -72,27 +72,13 @@ public class BlobCowTest {
     BlobCow source = createBlobWithContents(sourceBlobId, contents);
     assertEquals(contents, StorageIntegrationUtils.readContents(source));
 
+    List<CloudResourceUid> record = CleanupRecorder.startNewRecordForTesting();
     assertNull(storageCow.get(targetBlobId));
     CopyWriter copyWriter = source.copyTo(targetBlobId);
     copyWriter.getResult();
     BlobCow target = storageCow.get(targetBlobId);
+
     assertEquals(contents, StorageIntegrationUtils.readContents(target));
-
-    assertTrue(source.delete());
-    assertTrue(target.delete());
-  }
-
-  @Test
-  public void copyToRecorded() throws Exception {
-    BlobId sourceBlobId =
-        BlobId.of(reusableBucket.getBucketInfo().getName(), IntegrationUtils.randomName());
-    BlobCow source = storageCow.create(BlobInfo.newBuilder(sourceBlobId).build());
-
-    List<CloudResourceUid> record = CleanupRecorder.startNewRecordForTesting();
-    BlobId targetBlobId =
-        BlobId.of(reusableBucket.getBucketInfo().getName(), IntegrationUtils.randomName());
-    source.copyTo(targetBlobId).getResult();
-
     assertThat(
         record,
         Matchers.contains(
@@ -100,8 +86,8 @@ public class BlobCowTest {
                 .blobName(targetBlobId.getName())
                 .bucketName(targetBlobId.getBucket())));
 
-    source.delete();
-    storageCow.delete(targetBlobId);
+    assertTrue(source.delete());
+    assertTrue(target.delete());
   }
 
   @Test


### PR DESCRIPTION
I'm a little unsure about whether to keep splitting out the recording into another test, or whether to add it to the existing test for the cow creation operations. Technically testing a diffeerent behavior, but there's not much to these tests and it's a fair amount of repetition as-is.