### PR TITLE
[PF-25] Add support to get and delete dataset by DatasetId instead string name

### DIFF
--- a/google-bigquery/gradle.properties
+++ b/google-bigquery/gradle.properties
@@ -1,2 +1,2 @@
 group = bio.terra.cloud-resource-lib
-version = 0.0.7-SNAPSHOT
+version = 0.0.8-SNAPSHOT

--- a/google-bigquery/gradle.properties
+++ b/google-bigquery/gradle.properties
@@ -1,2 +1,2 @@
 group = bio.terra.cloud-resource-lib
-version = 0.0.6-SNAPSHOT
+version = 0.0.7-SNAPSHOT

--- a/google-bigquery/gradle.properties
+++ b/google-bigquery/gradle.properties
@@ -1,2 +1,2 @@
 group = bio.terra.cloud-resource-lib
-version = 0.0.8-SNAPSHOT
+version = 0.0.9-SNAPSHOT

--- a/google-bigquery/src/main/java/bio/terra/cloudres/google/bigquery/BigQueryCow.java
+++ b/google-bigquery/src/main/java/bio/terra/cloudres/google/bigquery/BigQueryCow.java
@@ -91,22 +91,22 @@ public class BigQueryCow {
 
   /** See {@link BigQuery#getDataset(String, DatasetOption...)}. */
   public DatasetCow getDataSet(String datasetId, DatasetOption... datasetOptions) {
-    return new DatasetCow(
-        clientConfig,
+    Dataset rawDataset =
         operationAnnotator.executeCowOperation(
             CloudOperation.GOOGLE_GET_DATASET,
             () -> bigQuery.getDataset(datasetId, datasetOptions),
-            () -> convert(DatasetId.of(datasetId), datasetOptions)));
+            () -> convert(DatasetId.of(datasetId), datasetOptions));
+    return (rawDataset == null) ? null : new DatasetCow(clientConfig, rawDataset);
   }
 
   /** See {@link BigQuery#getDataset(DatasetId, DatasetOption...)}. */
   public DatasetCow getDataSet(DatasetId datasetId, DatasetOption... datasetOptions) {
-    return new DatasetCow(
-        clientConfig,
+    Dataset rawDataset =
         operationAnnotator.executeCowOperation(
             CloudOperation.GOOGLE_GET_DATASET,
             () -> bigQuery.getDataset(datasetId, datasetOptions),
-            () -> convert(datasetId, datasetOptions)));
+            () -> convert(datasetId, datasetOptions));
+    return (rawDataset == null) ? null : new DatasetCow(clientConfig, rawDataset);
   }
 
   /** See {@link BigQuery#create(TableInfo, TableOption...)}. */
@@ -150,12 +150,12 @@ public class BigQueryCow {
 
   /** See {@link BigQuery#getTable(TableId, TableOption...)}. */
   public TableCow getTable(TableId tableId, TableOption... tableOptions) {
-    return new TableCow(
-        clientConfig,
+    Table rawTable =
         operationAnnotator.executeCowOperation(
             CloudOperation.GOOGLE_GET_BIGQUERY_TABLE,
             () -> bigQuery.getTable(tableId, tableOptions),
-            () -> convert(tableId, tableOptions)));
+            () -> convert(tableId, tableOptions));
+    return (rawTable == null) ? null : new TableCow(clientConfig, rawTable);
   }
 
   /** See {@link BigQuery#getTable(String, String, TableOption...)}. */

--- a/google-bigquery/src/main/java/bio/terra/cloudres/google/bigquery/BigQueryCow.java
+++ b/google-bigquery/src/main/java/bio/terra/cloudres/google/bigquery/BigQueryCow.java
@@ -81,6 +81,14 @@ public class BigQueryCow {
         () -> convert(DatasetId.of(datasetId), deleteOptions));
   }
 
+  /** See {@link BigQuery#delete(DatasetId, DatasetDeleteOption...)}. */
+  public boolean delete(DatasetId datasetId, DatasetDeleteOption... deleteOptions) {
+    return operationAnnotator.executeCowOperation(
+        CloudOperation.GOOGLE_DELETE_DATASET,
+        () -> bigQuery.delete(datasetId, deleteOptions),
+        () -> convert(datasetId, deleteOptions));
+  }
+
   /** See {@link BigQuery#getDataset(String, DatasetOption...)}. */
   public DatasetCow getDataSet(String datasetId, DatasetOption... datasetOptions) {
     return new DatasetCow(
@@ -89,6 +97,16 @@ public class BigQueryCow {
             CloudOperation.GOOGLE_GET_DATASET,
             () -> bigQuery.getDataset(datasetId, datasetOptions),
             () -> convert(DatasetId.of(datasetId), datasetOptions)));
+  }
+
+  /** See {@link BigQuery#getDataset(DatasetId, DatasetOption...)}. */
+  public DatasetCow getDataSet(DatasetId datasetId, DatasetOption... datasetOptions) {
+    return new DatasetCow(
+        clientConfig,
+        operationAnnotator.executeCowOperation(
+            CloudOperation.GOOGLE_GET_DATASET,
+            () -> bigQuery.getDataset(datasetId, datasetOptions),
+            () -> convert(datasetId, datasetOptions)));
   }
 
   /** See {@link BigQuery#create(TableInfo, TableOption...)}. */

--- a/google-bigquery/src/main/java/bio/terra/cloudres/google/bigquery/BigQueryCow.java
+++ b/google-bigquery/src/main/java/bio/terra/cloudres/google/bigquery/BigQueryCow.java
@@ -90,7 +90,7 @@ public class BigQueryCow {
   }
 
   /** See {@link BigQuery#getDataset(String, DatasetOption...)}. */
-  public DatasetCow getDataSet(String datasetId, DatasetOption... datasetOptions) {
+  public DatasetCow getDataset(String datasetId, DatasetOption... datasetOptions) {
     Dataset rawDataset =
         operationAnnotator.executeCowOperation(
             CloudOperation.GOOGLE_GET_DATASET,
@@ -100,7 +100,7 @@ public class BigQueryCow {
   }
 
   /** See {@link BigQuery#getDataset(DatasetId, DatasetOption...)}. */
-  public DatasetCow getDataSet(DatasetId datasetId, DatasetOption... datasetOptions) {
+  public DatasetCow getDataset(DatasetId datasetId, DatasetOption... datasetOptions) {
     Dataset rawDataset =
         operationAnnotator.executeCowOperation(
             CloudOperation.GOOGLE_GET_DATASET,

--- a/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/BigQueryCowTest.java
+++ b/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/BigQueryCowTest.java
@@ -98,7 +98,7 @@ public class BigQueryCowTest {
 
     assertNotNull(bigQueryCow.getDataSet(datasetId));
     bigQueryCow.delete(datasetId);
-    assertNull(bigQueryCow.getDataSet(datasetId).getDatasetInfo());
+    assertNull(bigQueryCow.getDataSet(datasetId));
   }
 
   @Test
@@ -108,7 +108,7 @@ public class BigQueryCowTest {
 
     assertNotNull(bigQueryCow.getDataSet(datasetId));
     bigQueryCow.delete(datasetId);
-    assertNull(bigQueryCow.getDataSet(datasetId).getDatasetInfo());
+    assertNull(bigQueryCow.getDataSet(datasetId));
   }
 
   @Test
@@ -152,7 +152,7 @@ public class BigQueryCowTest {
     assertNotNull(bigQueryCow.getTable(tableCow.getTableInfo().getTableId()).getTableInfo());
 
     bigQueryCow.delete(tableId);
-    assertNull(bigQueryCow.getTable(tableId).getTableInfo());
+    assertNull(bigQueryCow.getTable(tableId));
   }
 
   @Test

--- a/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/BigQueryCowTest.java
+++ b/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/BigQueryCowTest.java
@@ -92,9 +92,19 @@ public class BigQueryCowTest {
   }
 
   @Test
-  public void deleteDataset() {
+  public void deleteDataset_byStringName() {
     DatasetCow datasetCow = resourceTracker.createDatasetCow();
     String datasetId = datasetCow.getDatasetInfo().getDatasetId().getDataset();
+
+    assertNotNull(bigQueryCow.getDataSet(datasetId));
+    bigQueryCow.delete(datasetId);
+    assertNull(bigQueryCow.getDataSet(datasetId).getDatasetInfo());
+  }
+
+  @Test
+  public void deleteDataset_byDatasetId() {
+    DatasetCow datasetCow = resourceTracker.createDatasetCow();
+    DatasetId datasetId = datasetCow.getDatasetInfo().getDatasetId();
 
     assertNotNull(bigQueryCow.getDataSet(datasetId));
     bigQueryCow.delete(datasetId);

--- a/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/BigQueryCowTest.java
+++ b/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/BigQueryCowTest.java
@@ -56,7 +56,7 @@ public class BigQueryCowTest {
     assertEquals(
         datasetCow.getDatasetInfo(),
         bigQueryCow
-            .getDataSet(datasetCow.getDatasetInfo().getDatasetId().getDataset())
+            .getDataset(datasetCow.getDatasetInfo().getDatasetId().getDataset())
             .getDatasetInfo());
     DatasetId datasetId = datasetCow.getDatasetInfo().getDatasetId();
     assertThat(
@@ -75,7 +75,7 @@ public class BigQueryCowTest {
     String datasetId = datasetCow.getDatasetInfo().getDatasetId().getDataset();
 
     assertEquals(
-        datasetId, bigQueryCow.getDataSet(datasetId).getDatasetInfo().getDatasetId().getDataset());
+        datasetId, bigQueryCow.getDataset(datasetId).getDatasetInfo().getDatasetId().getDataset());
   }
 
   @Test
@@ -83,12 +83,12 @@ public class BigQueryCowTest {
     DatasetCow datasetCow = resourceTracker.createDatasetCow();
     String datasetId = datasetCow.getDatasetInfo().getDatasetId().getDataset();
 
-    assertNull(bigQueryCow.getDataSet(datasetId).getDatasetInfo().getDescription());
+    assertNull(bigQueryCow.getDataset(datasetId).getDatasetInfo().getDescription());
 
     String description = "new description";
     bigQueryCow.update(DatasetInfo.newBuilder(datasetId).setDescription("new description").build());
 
-    assertEquals(description, bigQueryCow.getDataSet(datasetId).getDatasetInfo().getDescription());
+    assertEquals(description, bigQueryCow.getDataset(datasetId).getDatasetInfo().getDescription());
   }
 
   @Test
@@ -96,9 +96,9 @@ public class BigQueryCowTest {
     DatasetCow datasetCow = resourceTracker.createDatasetCow();
     String datasetId = datasetCow.getDatasetInfo().getDatasetId().getDataset();
 
-    assertNotNull(bigQueryCow.getDataSet(datasetId));
+    assertNotNull(bigQueryCow.getDataset(datasetId));
     bigQueryCow.delete(datasetId);
-    assertNull(bigQueryCow.getDataSet(datasetId));
+    assertNull(bigQueryCow.getDataset(datasetId));
   }
 
   @Test
@@ -106,9 +106,9 @@ public class BigQueryCowTest {
     DatasetCow datasetCow = resourceTracker.createDatasetCow();
     DatasetId datasetId = datasetCow.getDatasetInfo().getDatasetId();
 
-    assertNotNull(bigQueryCow.getDataSet(datasetId));
+    assertNotNull(bigQueryCow.getDataset(datasetId));
     bigQueryCow.delete(datasetId);
-    assertNull(bigQueryCow.getDataSet(datasetId));
+    assertNull(bigQueryCow.getDataset(datasetId));
   }
 
   @Test

--- a/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/DatasetCowTest.java
+++ b/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/DatasetCowTest.java
@@ -59,7 +59,7 @@ public class DatasetCowTest {
     DatasetCow datasetCow = resourceTracker.createDatasetCow();
     String datasetId = datasetCow.getDatasetInfo().getDatasetId().getDataset();
 
-    assertNotNull(bigQueryCow.getDataSet(datasetId));
+    assertNotNull(bigQueryCow.getDataset(datasetId));
     datasetCow.delete();
     assertNull(datasetCow.reload().getDatasetInfo());
   }

--- a/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/TableCowTest.java
+++ b/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/TableCowTest.java
@@ -1,13 +1,13 @@
 package bio.terra.cloudres.google.bigquery;
 
-import static bio.terra.cloudres.google.bigquery.BigQueryIntegrationUtils.assertTableIdEqual;
-import static bio.terra.cloudres.google.bigquery.BigQueryIntegrationUtils.defaultBigQueryCow;
-import static org.junit.jupiter.api.Assertions.*;
-
 import bio.terra.cloudres.testing.IntegrationUtils;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.Table;
 import org.junit.jupiter.api.*;
+
+import static bio.terra.cloudres.google.bigquery.BigQueryIntegrationUtils.assertTableIdEqual;
+import static bio.terra.cloudres.google.bigquery.BigQueryIntegrationUtils.defaultBigQueryCow;
+import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("integration")
 public class TableCowTest {
@@ -67,6 +67,6 @@ public class TableCowTest {
     TableCow tableCow = resourceTracker.createTableCow();
     tableCow.delete();
 
-    assertNull(bigQueryCow.getTable(tableCow.getTableInfo().getTableId()).getTableInfo());
+    assertNull(bigQueryCow.getTable(tableCow.getTableInfo().getTableId()));
   }
 }

--- a/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/TableCowTest.java
+++ b/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/TableCowTest.java
@@ -1,13 +1,13 @@
 package bio.terra.cloudres.google.bigquery;
 
+import static bio.terra.cloudres.google.bigquery.BigQueryIntegrationUtils.assertTableIdEqual;
+import static bio.terra.cloudres.google.bigquery.BigQueryIntegrationUtils.defaultBigQueryCow;
+import static org.junit.jupiter.api.Assertions.*;
+
 import bio.terra.cloudres.testing.IntegrationUtils;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.Table;
 import org.junit.jupiter.api.*;
-
-import static bio.terra.cloudres.google.bigquery.BigQueryIntegrationUtils.assertTableIdEqual;
-import static bio.terra.cloudres.google.bigquery.BigQueryIntegrationUtils.defaultBigQueryCow;
-import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("integration")
 public class TableCowTest {


### PR DESCRIPTION
Janitor needs this to delete/query dataset. But Janitor's Google Credential are in different project, so it needs the full DatasetId object which contains project id and dataset name. 

Also, change COW to return null if the cloud resource inside is null. 