### PR TITLE
[no ticket] make blob & bucket not public in test

### DIFF
--- a/google-storage/src/test/java/bio/terra/cloudres/google/storage/BucketCowTest.java
+++ b/google-storage/src/test/java/bio/terra/cloudres/google/storage/BucketCowTest.java
@@ -65,7 +65,7 @@ public class BucketCowTest {
     BucketCow bucketCow = storageCow.create(BucketInfo.of(bucketName));
 
     List<Acl> defaultAcl = storageCow.get(bucketName).getBucketInfo().getAcl();
-    Acl acl = Acl.newBuilder(new Acl.User(getTestUserEmailAddress()), Acl.Role.WRITER).build();
+    Acl acl = Acl.newBuilder(new Acl.User(getTestUserEmailAddress()), Acl.Role.READER).build();
     bucketCow.updateAcl(acl);
 
     // Verify that new ACL is added and previous Acls still exist.

--- a/google-storage/src/test/java/bio/terra/cloudres/google/storage/BucketCowTest.java
+++ b/google-storage/src/test/java/bio/terra/cloudres/google/storage/BucketCowTest.java
@@ -1,7 +1,6 @@
 package bio.terra.cloudres.google.storage;
 
-import static bio.terra.cloudres.google.storage.StorageIntegrationUtils.assertAclsMatch;
-import static bio.terra.cloudres.google.storage.StorageIntegrationUtils.createBlobWithContents;
+import static bio.terra.cloudres.google.storage.StorageIntegrationUtils.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertNull;
@@ -66,8 +65,9 @@ public class BucketCowTest {
     BucketCow bucketCow = storageCow.create(BucketInfo.of(bucketName));
 
     List<Acl> defaultAcl = storageCow.get(bucketName).getBucketInfo().getAcl();
-    Acl acl = Acl.newBuilder(Acl.User.ofAllAuthenticatedUsers(), Acl.Role.READER).build();
+    Acl acl = Acl.newBuilder(new Acl.User(getTestUserEmailAddress()), Acl.Role.WRITER).build();
     bucketCow.updateAcl(acl);
+
     // Verify that new ACL is added and previous Acls still exist.
     List<Acl> expectedAcl = new ArrayList<>(defaultAcl);
     expectedAcl.add(acl);

--- a/google-storage/src/test/java/bio/terra/cloudres/google/storage/StorageCowTest.java
+++ b/google-storage/src/test/java/bio/terra/cloudres/google/storage/StorageCowTest.java
@@ -1,6 +1,6 @@
 package bio.terra.cloudres.google.storage;
 
-import static bio.terra.cloudres.google.storage.StorageIntegrationUtils.assertAclsMatch;
+import static bio.terra.cloudres.google.storage.StorageIntegrationUtils.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -97,7 +97,8 @@ public class StorageCowTest {
     BlobId blobId =
         BlobId.of(reusableBucket.getBucketInfo().getName(), IntegrationUtils.randomName());
     storageCow.create(BlobInfo.newBuilder(blobId).build());
-    Acl.User entity = Acl.User.ofAllAuthenticatedUsers();
+
+    Acl.User entity = new Acl.User(getTestUserEmailAddress());
     assertNull(storageCow.getAcl(blobId, entity));
 
     Acl acl = Acl.newBuilder(entity, Acl.Role.READER).build();
@@ -117,7 +118,7 @@ public class StorageCowTest {
     storageCow.create(BucketInfo.of(bucketName));
 
     List<Acl> defaultAcl = storageCow.get(bucketName).getBucketInfo().getAcl();
-    Acl acl = Acl.newBuilder(Acl.User.ofAllAuthenticatedUsers(), Acl.Role.READER).build();
+    Acl acl = Acl.newBuilder(new Acl.User(getTestUserEmailAddress()), Acl.Role.READER).build();
     storageCow.updateAcl(bucketName, acl);
     // Verify that new ACL is added and previous Acls still exist.
     List<Acl> expectedAcl = new ArrayList<>(defaultAcl);

--- a/google-storage/src/test/java/bio/terra/cloudres/google/storage/StorageIntegrationUtils.java
+++ b/google-storage/src/test/java/bio/terra/cloudres/google/storage/StorageIntegrationUtils.java
@@ -37,6 +37,10 @@ class StorageIntegrationUtils {
         .build();
   }
 
+  static String getTestUserEmailAddress() {
+    return IntegrationCredentials.getUserGoogleCredentialsOrDie().getClientEmail();
+  }
+
   static String readContents(BlobCow blob) throws IOException {
     try (InputStreamReader reader = new InputStreamReader(Channels.newInputStream(blob.reader()))) {
       return CharStreams.toString(reader);


### PR DESCRIPTION
It is recommanded from Broad InfoSecs that not to make cloud resource public. 