### PR TITLE
[PF-571] Misc CI improvements: avoid duplicate unit tests, cache Gradle packages, run spotlessApply

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -62,18 +62,24 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      # See https://github.com/actions/cache/blob/main/examples.md#java---gradle
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Build with Gradle
+      - name: Build, assemble and test
         run: ./gradlew build -x minniekenny # skip minniekenny
       # TODO(CA-814): Determine how to run tests based on modified packages.
-      - name: Test
-        id: unit-test
-        run: ./gradlew test -x minniekenny
-      - name: Integration Test
+      - name: Integration test
         id: integration-test
         run: ./gradlew integrationTest
-      - name: Upload Test Reports
+      - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,15 @@ jobs:
           echo ::add-mask::$ARTIFACTORY_USERNAME
           echo ::set-output name=artifactory-password::$ARTIFACTORY_PASSWORD
           echo ::add-mask::$ARTIFACTORY_PASSWORD
+      # See https://github.com/actions/cache/blob/main/examples.md#java---gradle
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Publish packages

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Automatically fix linting issues:
 ./gradlew spotlessApply
 ```
 
+## Publishing an update
+
+The version number of each sub-project is handled manually with a two-step process:
+
+1. Bump the version of the appropriate sub-project(s) in the same PR as the code changes.
+2. Merge to the main branch, and then create a new GitHub release. The publish.yml action will run on the tagged
+   release, pushing new packages to Artifactory.
+
 ## Adding a new package
 Cloud API client libraries are wrapped in separate CRL packages to allow clients to only include the libraries that they
 use. To add a new CRL package to support a new client library:

--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,8 @@ subprojects { subproject ->
 
     java {
         withJavadocJar()
+        // Builds sources into the published package as part of the 'assemble' task.
+        withSourcesJar()
     }
 
     task minniekenny(type: Exec) {

--- a/common/src/testFixtures/java/bio/terra/cloudres/testing/IntegrationUtils.java
+++ b/common/src/testFixtures/java/bio/terra/cloudres/testing/IntegrationUtils.java
@@ -41,8 +41,9 @@ public class IntegrationUtils {
 
   /**
    * Sets longer timeout because some operation(e.g. Dns.ManagedZones.Create) may take longer than
-   * default timeout. We pass a {@link HttpRequestInitializer} to accept a requestInitializer to allow chaining, since
-   * API clients have exactly one initializer and credentials are typically required as well.
+   * default timeout. We pass a {@link HttpRequestInitializer} to accept a requestInitializer to
+   * allow chaining, since API clients have exactly one initializer and credentials are typically
+   * required as well.
    */
   public static HttpRequestInitializer setHttpTimeout(
       final HttpRequestInitializer requestInitializer) {

--- a/google-dns/src/test/java/bio/terra/cloudres/google/dns/DnsCowTest.java
+++ b/google-dns/src/test/java/bio/terra/cloudres/google/dns/DnsCowTest.java
@@ -41,7 +41,8 @@ public class DnsCowTest {
                 Defaults.jsonFactory(),
                 setHttpTimeout(
                     new HttpCredentialsAdapter(
-                        IntegrationCredentials.getAdminGoogleCredentialsOrDie().createScoped(DnsScopes.all()))))
+                        IntegrationCredentials.getAdminGoogleCredentialsOrDie()
+                            .createScoped(DnsScopes.all()))))
             .setApplicationName(IntegrationUtils.DEFAULT_CLIENT_NAME));
   }
 


### PR DESCRIPTION
These were a few cleanups coming out of my work on https://github.com/DataBiosphere/terra-cloud-resource-lib/pull/71.