### PR TITLE
PF-744 Bump all the gradle.properties for PR #85.

### DIFF
--- a/cloud-resource-schema/gradle.properties
+++ b/cloud-resource-schema/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.7.0
+version = 0.8.0

--- a/common/gradle.properties
+++ b/common/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.7.0
+version = 0.8.0

--- a/google-api-services-common/gradle.properties
+++ b/google-api-services-common/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.7.0
+version = 0.8.0

--- a/google-bigquery/gradle.properties
+++ b/google-bigquery/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.8.1
+version = 0.9.0

--- a/google-billing/gradle.properties
+++ b/google-billing/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.7.0
+version = 0.8.0

--- a/google-cloudresourcemanager/gradle.properties
+++ b/google-cloudresourcemanager/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.7.0
+version = 0.8.0

--- a/google-compute/gradle.properties
+++ b/google-compute/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.8.0
+version = 0.9.0

--- a/google-dns/gradle.properties
+++ b/google-dns/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.7.0
+version = 0.8.0

--- a/google-iam/gradle.properties
+++ b/google-iam/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.7.0
+version = 0.8.0

--- a/google-notebooks/gradle.properties
+++ b/google-notebooks/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.5.0
+version = 0.6.0

--- a/google-serviceusage/gradle.properties
+++ b/google-serviceusage/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.7.0
+version = 0.8.0

--- a/google-storage/gradle.properties
+++ b/google-storage/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.8.0
+version = 0.9.0

--- a/google-storage/gradle.properties
+++ b/google-storage/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.9.0
+version = 0.10.0


### PR DESCRIPTION
I forgot to check for this in #85. We haven't figured out a way to automate this on a per-package level yet, so we're still at manually modifying the `gradle.properties` files used to create the release version, which at least lets us increment the packages independently.