### PR TITLE
bump version to match manual publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,17 +148,17 @@ artifactory {
         }
         defaults {
             publications(
-                    'cloud-resource-schema',
-                    'common',
-                    'google-api-services-common',
-                    'google-bigquery',
-                    'google-billing',
-                    'google-cloudresourcemanager',
-                    'google-compute',
-                    'google-dns',
-                    'google-iam',
-                    'google-notebooks',
-                    'google-serviceusage',
+//                    'cloud-resource-schema',
+//                    'common',
+//                    'google-api-services-common',
+//                    'google-bigquery',
+//                    'google-billing',
+//                    'google-cloudresourcemanager',
+//                    'google-compute',
+//                    'google-dns',
+//                    'google-iam',
+//                    'google-notebooks',
+//                    'google-serviceusage',
                     'google-storage')
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -148,17 +148,17 @@ artifactory {
         }
         defaults {
             publications(
-//                    'cloud-resource-schema',
-//                    'common',
-//                    'google-api-services-common',
-//                    'google-bigquery',
-//                    'google-billing',
-//                    'google-cloudresourcemanager',
-//                    'google-compute',
-//                    'google-dns',
-//                    'google-iam',
-//                    'google-notebooks',
-//                    'google-serviceusage',
+                    'cloud-resource-schema',
+                    'common',
+                    'google-api-services-common',
+                    'google-bigquery',
+                    'google-billing',
+                    'google-cloudresourcemanager',
+                    'google-compute',
+                    'google-dns',
+                    'google-iam',
+                    'google-notebooks',
+                    'google-serviceusage',
                     'google-storage')
         }
     }

--- a/google-storage/gradle.properties
+++ b/google-storage/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.11.0
+version = 0.12.0


### PR DESCRIPTION
I just published [google-storage](https://broadinstitute.jfrog.io/broadinstitute/libs-release-local/bio/terra/cloud-resource-lib/google-storage/0.12.0/) as 0.12.0 to make sure I didn't conflict with any existing versions. I think I skipped 0.11.0 in the process. Bumping it in gradle.properties to match reality.

