### PR TITLE
[IA-2860] Azure models/tests for Network / Disk / VM resources CREATE / GET / DELETE

### DIFF
--- a/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/BaseRequestData.java
+++ b/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/BaseRequestData.java
@@ -1,0 +1,26 @@
+package bio.terra.cloudres.azure.resourcemanager.compute;
+
+import bio.terra.cloudres.azure.resourcemanager.resources.AzureRequestData;
+import com.azure.core.management.Region;
+import com.google.gson.JsonObject;
+
+public abstract class BaseRequestData extends AzureRequestData {
+    protected final String name;
+    protected final Region region;
+    protected final String resourceGroupName;
+
+    protected BaseRequestData(String resourceGroupName, String name, Region region) {
+        this.name = name;
+        this.region = region;
+        this.resourceGroupName = resourceGroupName;
+    }
+
+    @Override
+    public JsonObject getRequestData() {
+        JsonObject requestData = new JsonObject();
+        requestData.addProperty("resourceGroupName", resourceGroupName);
+        requestData.addProperty("name", name);
+        requestData.addProperty("region", region.name());
+        return requestData;
+    }
+}

--- a/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/ComputeManagerOperation.java
+++ b/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/ComputeManagerOperation.java
@@ -4,5 +4,8 @@ import bio.terra.cloudres.common.CloudOperation;
 
 /** {@link CloudOperation} for using Azure ComputeManager API. */
 public enum ComputeManagerOperation implements CloudOperation {
-  AZURE_CREATE_PUBLIC_IP
+  AZURE_CREATE_PUBLIC_IP,
+  AZURE_CREATE_DISK,
+  AZURE_CREATE_NETWORK,
+  AZURE_CREATE_VM
 }

--- a/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/CreatePublicIpRequestData.java
+++ b/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/CreatePublicIpRequestData.java
@@ -1,28 +1,18 @@
 package bio.terra.cloudres.azure.resourcemanager.compute;
 
-import bio.terra.cloudres.azure.resourcemanager.resources.AbstractRequestData;
+import bio.terra.cloudres.azure.resourcemanager.resources.AzureRequestData;
 import com.azure.core.management.Region;
 import com.google.gson.JsonObject;
 
 /** Data for an Azure IP creation request. */
-public class CreatePublicIpRequestData extends AbstractRequestData {
-  private final String resourceGroupName;
-  private final String name;
-  private final Region region;
+public class CreatePublicIpRequestData extends BaseRequestData {
 
-  public CreatePublicIpRequestData(String resourceGroupName, String name, Region region) {
-    super(ComputeManagerOperation.AZURE_CREATE_PUBLIC_IP);
-    this.resourceGroupName = resourceGroupName;
-    this.name = name;
-    this.region = region;
+  protected PublicIpRequestData(String resourceGroupName, String name, Region region) {
+    super(ComputeManagerOperation.AZURE_CREATE_PUBLIC_IP, resourceGroupName, name, region);
   }
 
   @Override
-  public JsonObject serialize() {
-    JsonObject requestData = new JsonObject();
-    requestData.addProperty("resourceGroupName", resourceGroupName);
-    requestData.addProperty("name", name);
-    requestData.addProperty("region", region.name());
-    return requestData;
+  public JsonObject getRequestData() {
+    return super.getRequestData();
   }
 }

--- a/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/DiskRequestData.java
+++ b/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/DiskRequestData.java
@@ -1,0 +1,22 @@
+package bio.terra.cloudres.azure.resourcemanager.compute;
+
+import bio.terra.cloudres.azure.resourcemanager.resources.AzureRequestData;
+import com.azure.core.management.Region;
+import com.google.gson.JsonObject;
+
+public class DiskRequestData extends BaseRequestData {
+    private final int size;
+    //TODO: type (e.g. SSD)?
+
+    public DiskRequestData(String resourceGroupName, String name, Region region, int size) {
+        super(resourceGroupName, name, region);
+        this.size = size;
+    }
+
+    @Override
+    public JsonObject getRequestData() {
+        JsonObject requestData = super.getRequestData();
+        requestData.addProperty("size", size);
+        return requestData;
+    }
+}

--- a/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/NetworkRequestData.java
+++ b/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/NetworkRequestData.java
@@ -1,0 +1,20 @@
+package bio.terra.cloudres.azure.resourcemanager.compute;
+
+import com.azure.core.management.Region;
+import com.google.gson.JsonObject;
+
+public class NetworkRequestData extends BaseRequestData {
+    private final String subnetName;
+
+    public NetworkRequestData(String resourceGroupName, String name, Region region, String subnetName) {
+        super(resourceGroupName, name, region);
+        this.subnetName = subnetName;
+    }
+
+    @Override
+    public JsonObject getRequestData() {
+        JsonObject requestData =  super.getRequestData();
+        requestData.addProperty("subnetName", subnetName);
+        return requestData;
+    }
+}

--- a/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/VMRequestData.java
+++ b/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/VMRequestData.java
@@ -2,13 +2,33 @@ package bio.terra.cloudres.azure.resourcemanager.compute;
 
 import bio.terra.cloudres.azure.resourcemanager.resources.AzureRequestData;
 import com.azure.core.management.Region;
+import com.azure.resourcemanager.compute.models.Disk;
+import com.azure.resourcemanager.network.models.Network;
+import com.azure.resourcemanager.network.models.PublicIpAddress;
 import com.google.gson.JsonObject;
 
-public class VMRequestData extends AzureRequestData {
+public class VMRequestData extends BaseRequestData {
+    private final Network network;
+    private final String subnetName;
+    private final PublicIpAddress ip;
+    private final Disk disk;
 
+    public VMRequestData(String resourceGroupName, String name, Region region, Network network, String subnetName, PublicIpAddress ip, Disk disk) {
+        super(resourceGroupName, name, region);
+        this.network = network;
+        this.subnetName = subnetName;
+        this.ip = ip;
+        this.disk = disk;
+    }
 
     @Override
     public JsonObject getRequestData() {
-        return null;
+        JsonObject requestData =  super.getRequestData();
+        requestData.addProperty("network", network.name());
+        requestData.addProperty("subnetName", subnetName);
+        requestData.addProperty("ip", ip.ipAddress());
+        requestData.addProperty("disk", disk.name());
+        return requestData;
+
     }
 }

--- a/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/VMRequestData.java
+++ b/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/VMRequestData.java
@@ -29,6 +29,5 @@ public class VMRequestData extends BaseRequestData {
         requestData.addProperty("ip", ip.ipAddress());
         requestData.addProperty("disk", disk.name());
         return requestData;
-
     }
 }

--- a/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/VMRequestData.java
+++ b/azure-resourcemanager-compute/src/main/java/bio/terra/cloudres/azure/resourcemanager/compute/VMRequestData.java
@@ -1,0 +1,14 @@
+package bio.terra.cloudres.azure.resourcemanager.compute;
+
+import bio.terra.cloudres.azure.resourcemanager.resources.AzureRequestData;
+import com.azure.core.management.Region;
+import com.google.gson.JsonObject;
+
+public class VMRequestData extends AzureRequestData {
+
+
+    @Override
+    public JsonObject getRequestData() {
+        return null;
+    }
+}

--- a/azure-resourcemanager-compute/src/test/java/bio/terra/cloudres/azure/resourcemanager/compute/ComputeManagerCowTest.java
+++ b/azure-resourcemanager-compute/src/test/java/bio/terra/cloudres/azure/resourcemanager/compute/ComputeManagerCowTest.java
@@ -1,42 +1,41 @@
 package bio.terra.cloudres.azure.resourcemanager.compute;
 
-import bio.terra.cloudres.azure.resourcemanager.resources.AzureIntegrationUtils;
-import bio.terra.cloudres.azure.resourcemanager.resources.Defaults;
-import bio.terra.cloudres.testing.IntegrationUtils;
-import com.azure.core.management.Region;
-import com.azure.core.management.exception.ManagementException;
-import com.azure.resourcemanager.network.models.PublicIpAddress;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import static bio.terra.cloudres.azure.resourcemanager.compute.ComputeManagerIntegrationUtils.defaultComputeManagerCow;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Tag("integration")
-// Note: disabled because we have not yet added Azure test environment setup to vault.
-@Disabled
-public class ComputeManagerCowTest {
-  private static final Logger logger = LoggerFactory.getLogger(ComputeManagerCowTest.class);
-  private static final ComputeManagerCow computeManagerCow =
-      ComputeManagerCow.create(
-          IntegrationUtils.DEFAULT_CLIENT_CONFIG,
-          AzureIntegrationUtils.getAdminAzureCredentialsOrDie(),
-          AzureIntegrationUtils.getUserAzureProfileOrDie());
+import bio.terra.cloudres.azure.resourcemanager.resources.Defaults;
+import com.azure.core.management.Region;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.compute.models.*;
+import com.azure.resourcemanager.network.models.Network;
+import com.azure.resourcemanager.network.models.NetworkSecurityGroup;
+import com.azure.resourcemanager.network.models.PublicIpAddress;
 
-  private static final String resourceGroupName = AzureIntegrationUtils.getResuableResourceGroup();
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.azure.resourcemanager.network.models.SecurityRuleProtocol;
+import com.azure.resourcemanager.resources.fluentcore.model.Creatable;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.*;
+
+@Tag("integration")
+public class ComputeManagerCowTest {
+  private static final ComputeManagerCow computeManagerCow = defaultComputeManagerCow();
+  private static final Region DEFAULT_REGION = Region.US_EAST;
+
+  // TODO: THESE ARE PUBLIC CREDS, TAKEN FROM
+  // From https://github.com/Azure-Samples/network-java-manage-virtual-network/blob/master/src/main/java/com/azure/resourcemanager/network/samples/ManageVirtualNetwork.java
+  private static final String userName = "tirekicker";
+  private static final String sshKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.com";
 
   @Test
   public void createListDeletePublicIp() {
     // Create public IP
-    final String name = "crl-integration-public-ip";
+    final String name = getAzureName("public-ip");
     PublicIpAddress createResponse = createPublicIp(name);
 
     // Verify get response
@@ -45,8 +44,7 @@ public class ComputeManagerCowTest {
             .computeManager()
             .networkManager()
             .publicIpAddresses()
-            .getByResourceGroup(resourceGroupName, name);
-    logger.info("GOT IP " + getResponse.ipAddress());
+            .getByResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup(), name);
     assertEquals(name, getResponse.name());
     assertEquals(createResponse.fqdn(), getResponse.fqdn());
     assertEquals(createResponse.ipAddress(), getResponse.ipAddress());
@@ -54,10 +52,10 @@ public class ComputeManagerCowTest {
     // Verify list response
     Stream<PublicIpAddress> listResponse =
         computeManagerCow.computeManager().networkManager().publicIpAddresses()
-            .listByResourceGroup(resourceGroupName).stream();
+            .listByResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup())
+            .stream();
     // There may be other public IPs from other tests.
-    assertThat(
-        listResponse.map(PublicIpAddress::name).collect(Collectors.toList()),
+    assertThat(listResponse.map(PublicIpAddress::name).collect(Collectors.toList()),
         Matchers.hasItem(name));
 
     // Delete public IP
@@ -65,7 +63,7 @@ public class ComputeManagerCowTest {
         .computeManager()
         .networkManager()
         .publicIpAddresses()
-        .deleteByResourceGroup(resourceGroupName, name);
+        .deleteByResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup(), name);
 
     // Verify get response throws 404
     ManagementException e =
@@ -76,11 +74,180 @@ public class ComputeManagerCowTest {
                     .computeManager()
                     .networkManager()
                     .publicIpAddresses()
-                    .getByResourceGroup(resourceGroupName, name));
+                    .getByResourceGroup(
+                        ComputeManagerIntegrationUtils.getReusableResourceGroup(), name));
     assertEquals(404, e.getResponse().getStatusCode());
   }
 
-  // TODO add more tests building up to VM creation
+  @Test
+  public void createListDeleteDisk() {
+    final String name = getAzureName("disk");
+    final int sizeInGB = 100;
+    Disk createDiskResponse = createDisk(name, sizeInGB);
+
+    // Verify get response
+    Disk getResponse =
+            computeManagerCow
+                    .computeManager()
+                    .disks()
+                    .getByResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup(), name);
+
+    assertEquals(name, getResponse.name());
+    assertEquals(createDiskResponse.sizeInGB(), getResponse.sizeInGB());
+    //TODO: this check could eventually be true depending on how we go about constructing create vm request (i.e. disk could be part of that or before)
+    assertEquals(getResponse.isAttachedToVirtualMachine(), false);
+
+
+    // Verify list response
+    Stream<Disk> listResponse =
+            computeManagerCow.computeManager().disks()
+                    .listByResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup())
+                    .stream();
+    // There may be other disks from other tests.
+    assertThat(listResponse.map(Disk::name).collect(Collectors.toList()),
+            Matchers.hasItem(name));
+
+    // Delete disk
+    computeManagerCow
+            .computeManager()
+            .disks()
+            .deleteByResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup(), name);
+
+    // Verify get response throws 404
+    ManagementException e =
+            assertThrows(
+                    ManagementException.class,
+                    () ->
+                            computeManagerCow
+                                    .computeManager()
+                                    .disks()
+                                    .getByResourceGroup(
+                                            ComputeManagerIntegrationUtils.getReusableResourceGroup(), name));
+    assertEquals(404, e.getResponse().getStatusCode());
+  }
+
+  @Test
+  public void createListDeleteNetwork() {
+    final String name = getAzureName("network");
+    final String subnetName = getAzureName("subnet");
+    final String addressCidr = "192.168.0.0/16";
+    final String subnetAddressCidr = "192.168.1.0/24";
+    Network createNetworkResponse = createNetwork(name, subnetName, addressCidr, subnetAddressCidr);
+
+    // Verify get response
+    Network getResponse =
+            computeManagerCow
+                    .computeManager()
+                    .networkManager()
+                    .networks()
+                    .getByResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup(), name);
+
+    assertEquals(name, getResponse.name());
+    assertEquals(createNetworkResponse.addressSpaces(), getResponse.addressSpaces());
+    assertThat(getResponse.addressSpaces(), Matchers.hasItem(addressCidr));
+    assertThat(getResponse.subnets().keySet(), Matchers.hasItem(subnetName));
+    assertEquals(getResponse.subnets().get(subnetName).addressPrefix(), createNetworkResponse.subnets().get(subnetName).addressPrefix());
+    assertEquals(getResponse.subnets().get(subnetName).addressPrefix(), subnetAddressCidr);
+
+    // Verify list response
+    Stream<Network> listResponse =
+            computeManagerCow.computeManager()
+                    .networkManager()
+                    .networks()
+                    .listByResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup())
+                    .stream();
+
+    // There may be other Network from other tests.
+    assertThat(listResponse.map(Network::name).collect(Collectors.toList()), Matchers.hasItem(name));
+
+    // Delete Network
+    computeManagerCow
+            .computeManager()
+            .networkManager()
+            .networks()
+            .deleteByResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup(), name);
+
+    // Verify get response throws 404
+    ManagementException e =
+            assertThrows(
+                    ManagementException.class,
+                    () ->
+                            computeManagerCow
+                                    .computeManager()
+                                    .networkManager()
+                                    .networks()
+                                    .getByResourceGroup(
+                                            ComputeManagerIntegrationUtils.getReusableResourceGroup(), name));
+    assertEquals(404, e.getResponse().getStatusCode());
+  }
+
+  @Test
+  public void createListDeleteVM() {
+    final String vmName = getAzureName("vm");
+    final String ipName = getAzureName("vm-public-ip");
+    final String diskName = getAzureName("vm-disk");
+    final String networkName = getAzureName("vm-network");
+    final String subnetName = getAzureName("vm-subnet");
+    final String addressCidr = "192.168.0.0/16";
+    final String subnetAddressCidr = "192.168.1.0/24";
+    final int sizeInGB = 100;
+
+    PublicIpAddress createIpResponse = createPublicIp(ipName);
+
+    Disk createDiskResponse = createDisk(diskName, sizeInGB);
+
+    Network createNetworkResponse = createNetwork(networkName, subnetName, addressCidr, subnetAddressCidr);
+
+    VirtualMachine createVMResponse = createVM(vmName, createNetworkResponse, subnetName, createIpResponse, createDiskResponse);
+
+    // Verify get response
+    VirtualMachine getVMResponse =
+            computeManagerCow
+                    .computeManager()
+                    .virtualMachines()
+                    .getByResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup(), vmName);
+
+    assertEquals(vmName, getVMResponse.name());
+    assertEquals(createVMResponse.regionName(), getVMResponse.regionName());
+    assertEquals(createVMResponse.resourceGroupName(), getVMResponse.resourceGroupName());
+
+    assertThat(getVMResponse.dataDisks().values().stream().map(VirtualMachineDataDisk::name).collect(Collectors.toList()),
+            Matchers.hasItem(diskName));
+
+    assertEquals(createVMResponse.getPrimaryPublicIPAddress().ipAddress(), getVMResponse.getPrimaryPublicIPAddress().ipAddress());
+
+    // Verify list response
+    Stream<VirtualMachine> listResponse =
+            computeManagerCow.computeManager()
+                    .virtualMachines()
+                    .listByResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup())
+                    .stream();
+
+    // There may be other VM from other tests.
+    assertThat(listResponse.map(VirtualMachine::name).collect(Collectors.toList()),
+            Matchers.hasItem(vmName));
+
+    // Delete Network
+    computeManagerCow
+            .computeManager()
+            .virtualMachines()
+            .deleteByResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup(), vmName);
+
+    // Verify get response throws 404
+    ManagementException e =
+            assertThrows(
+                    ManagementException.class,
+                    () ->
+                            computeManagerCow
+                                    .computeManager()
+                                    .networkManager()
+                                    .networks()
+                                    .getByResourceGroup(
+                                            ComputeManagerIntegrationUtils.getReusableResourceGroup(), vmName));
+    assertEquals(404, e.getResponse().getStatusCode());
+  }
+
+  //TODO test async vm creation if necessary
 
   private static PublicIpAddress createPublicIp(String name) {
     return computeManagerCow
@@ -89,10 +256,110 @@ public class ComputeManagerCowTest {
         .publicIpAddresses()
         .define(name)
         .withRegion(Region.US_EAST)
-        .withExistingResourceGroup(resourceGroupName)
+        .withExistingResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup())
         .withDynamicIP()
         .create(
             Defaults.buildContext(
-                new CreatePublicIpRequestData(resourceGroupName, name, Region.US_EAST)));
+                ComputeManagerOperation.AZURE_CREATE_PUBLIC_IP,
+                new PublicIpRequestData(
+                    ComputeManagerIntegrationUtils.getReusableResourceGroup(),
+                    name,
+                    Region.US_EAST)));
+  }
+
+  private static Disk createDisk(String name, int size) {
+    return computeManagerCow
+            .computeManager()
+            .disks()
+            .define(name)
+            .withRegion(DEFAULT_REGION)
+            .withExistingResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup())
+            .withData()
+            .withSizeInGB(size)
+//           .withSku(DiskSkuTypes.ULTRA_SSD_LRS)
+//            .withTags() should we label these resources?
+            .create(Defaults.buildContext(
+                    ComputeManagerOperation.AZURE_CREATE_DISK,
+                    new DiskRequestData(
+                            ComputeManagerIntegrationUtils.getReusableResourceGroup(),
+                            name,
+                            Region.US_EAST,
+                            size
+                    )
+            ));
+  }
+
+  private static Network createNetwork(String networkName, String subnetName, String addressSpaceCidr, String subnetAddressSpaceCidr) {
+    //TODO Its possible tuning is required, in particular the port in the subnet network security group
+    //most of this is taken from this very helpful snippet https://github.com/Azure-Samples/network-java-manage-virtual-network/blob/master/src/main/java/com/azure/resourcemanager/network/samples/ManageVirtualNetwork.java
+    NetworkSecurityGroup subnetNsg = computeManagerCow
+            .computeManager()
+            .networkManager()
+            .networkSecurityGroups()
+            .define(subnetName)
+            .withRegion(DEFAULT_REGION)
+            .withExistingResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup())
+            .defineRule("AllowHttpInComing")
+            .allowInbound()
+            .fromAddress("INTERNET")
+            .fromAnyPort()
+            .toAnyAddress()
+            .toPort(80)
+            .withProtocol(SecurityRuleProtocol.TCP)
+            .attach()
+            .defineRule("DenyInternetOutGoing")
+            .denyOutbound()
+            .fromAnyAddress()
+            .fromAnyPort()
+            .toAddress("INTERNET")
+            .toAnyPort()
+            .withAnyProtocol()
+            .attach()
+            .create();
+
+    return computeManagerCow
+            .computeManager()
+            .networkManager()
+            .networks()
+            .define(networkName)
+            .withRegion(DEFAULT_REGION)
+            .withExistingResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup())
+            .withAddressSpace(addressSpaceCidr)
+            .defineSubnet(subnetName)
+              .withAddressPrefix(subnetAddressSpaceCidr)
+              .withExistingNetworkSecurityGroup(subnetNsg)
+              .attach()
+            .create(Defaults.buildContext(
+                    ComputeManagerOperation.AZURE_CREATE_NETWORK,
+                    new NetworkRequestData(
+                            ComputeManagerIntegrationUtils.getReusableResourceGroup(),
+                            networkName,
+                            DEFAULT_REGION,
+                            subnetName
+                    )
+            ));
+  }
+
+  private static VirtualMachine createVM(String name, Network network, String subnetName, PublicIpAddress ip, Disk disk) {
+    VirtualMachine vm = computeManagerCow.computeManager().virtualMachines().define(name)
+            .withRegion(DEFAULT_REGION)
+            .withExistingResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup())
+            .withExistingPrimaryNetwork(network)
+            .withSubnet(subnetName)
+            .withPrimaryPrivateIPAddressDynamic()
+            .withNewPrimaryPublicIPAddress(ip.ipAddress())
+            .withPopularLinuxImage(KnownLinuxVirtualMachineImage.UBUNTU_SERVER_16_04_LTS)
+            .withRootUsername(userName)
+            .withSsh(sshKey)
+            .withExistingDataDisk(disk)
+            .withSize(VirtualMachineSizeTypes.fromString("Standard_D2a_v4"))
+            .create();
+
+    return vm;
+  }
+
+  private static String getAzureName(String tag) {
+    final String id = UUID.randomUUID().toString().substring(0,6);
+    return String.format("crl-integration-%s-%s", tag, id);
   }
 }

--- a/azure-resourcemanager-compute/src/test/java/bio/terra/cloudres/azure/resourcemanager/compute/ComputeManagerCowTest.java
+++ b/azure-resourcemanager-compute/src/test/java/bio/terra/cloudres/azure/resourcemanager/compute/ComputeManagerCowTest.java
@@ -353,7 +353,17 @@ public class ComputeManagerCowTest {
             .withSsh(sshKey)
             .withExistingDataDisk(disk)
             .withSize(VirtualMachineSizeTypes.fromString("Standard_D2a_v4"))
-            .create();
+            .create(Defaults.buildContext(
+                    ComputeManagerOperation.AZURE_CREATE_VM,
+                    new VMRequestData(
+                            ComputeManagerIntegrationUtils.getReusableResourceGroup(),
+                            name,
+                            DEFAULT_REGION,
+                            network,
+                            subnetName,
+                            ip,
+                            disk)
+              ));
 
     return vm;
   }

--- a/azure-resourcemanager-compute/src/test/java/bio/terra/cloudres/azure/resourcemanager/compute/ComputeManagerCowTest.java
+++ b/azure-resourcemanager-compute/src/test/java/bio/terra/cloudres/azure/resourcemanager/compute/ComputeManagerCowTest.java
@@ -103,6 +103,7 @@ public class ComputeManagerCowTest {
             computeManagerCow.computeManager().disks()
                     .listByResourceGroup(ComputeManagerIntegrationUtils.getReusableResourceGroup())
                     .stream();
+
     // There may be other disks from other tests.
     assertThat(listResponse.map(Disk::name).collect(Collectors.toList()),
             Matchers.hasItem(name));
@@ -227,7 +228,7 @@ public class ComputeManagerCowTest {
     assertThat(listResponse.map(VirtualMachine::name).collect(Collectors.toList()),
             Matchers.hasItem(vmName));
 
-    // Delete Network
+    // Delete VM
     computeManagerCow
             .computeManager()
             .virtualMachines()


### PR DESCRIPTION
This is organized into the addition of 3 new models with a base model. It adds a test for disks and network in isolation, and a test to create all resources (IP, network, Disk), and then attach these resources to a vm. It's possible to create a VM with new resources too, but it seemed more logical to leverage the fact that the code for creating the components individually was already tested. 

Its worth noting this test creates a VM synchronously, which causes the tests to take ~4minutes. It's possible that we will want to handle this async in the application, which the azure SDK supports natively along with a built-in polling interface, but it made more sense to do it sync for the tests since verification is required and blocking before subsequent steps.

Note that this is not merging to or based off main, it depends on the code in `rt-azure`, which provides the base models and Context/Cow setup, among other things.