### PR TITLE
Fix flakiness in BigQueryCowTest.listDataset()

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,12 +11,14 @@ plugins {
   id 'groovy-gradle-plugin'
 }
 
+// Specify repositories for plugins used in buildSrc/src/*.gradle.
 repositories {
   maven {
       url "https://plugins.gradle.org/m2/"
   }
 }
 
+// Specify versions for plugins used in buildSrc/src/*.gradle.
 dependencies {
     implementation group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: '3.27.2'
 }

--- a/google-bigquery/gradle.properties
+++ b/google-bigquery/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.12.0
+version = 0.13.0

--- a/google-bigquery/src/main/java/bio/terra/cloudres/google/bigquery/BigQueryCow.java
+++ b/google-bigquery/src/main/java/bio/terra/cloudres/google/bigquery/BigQueryCow.java
@@ -203,6 +203,12 @@ public class BigQueryCow {
         this.list = list;
       }
 
+      /** See {@link BigQuery.Datasets.List#setMaxResults(Long)}. */
+      public List setMaxResults(Long maxResults) {
+        this.list.setMaxResults(maxResults);
+        return this;
+      }
+
       public String getProjectId() {
         return list.getProjectId();
       }
@@ -211,6 +217,7 @@ public class BigQueryCow {
       protected JsonObject serialize() {
         JsonObject result = new JsonObject();
         result.addProperty("projectId", getProjectId());
+        result.addProperty("maxResults", list.getMaxResults());
         return result;
       }
     }

--- a/google-bigquery/src/main/java/bio/terra/cloudres/google/bigquery/BigQueryCow.java
+++ b/google-bigquery/src/main/java/bio/terra/cloudres/google/bigquery/BigQueryCow.java
@@ -203,7 +203,7 @@ public class BigQueryCow {
         this.list = list;
       }
 
-      /** See {@link BigQuery.Datasets.List#setMaxResults(Long)}. */
+      /** See {@link Bigquery.Datasets.List#setMaxResults(Long)} */
       public List setMaxResults(Long maxResults) {
         this.list.setMaxResults(maxResults);
         return this;

--- a/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/BigQueryCowTest.java
+++ b/google-bigquery/src/test/java/bio/terra/cloudres/google/bigquery/BigQueryCowTest.java
@@ -110,7 +110,12 @@ public class BigQueryCowTest {
     Dataset dataset1 = createDataset();
     Dataset dataset2 = createDataset();
 
-    DatasetList fetchedDatasets = bigQueryCow.datasets().list(projectId).execute();
+    // By default, Datasets.List returns 50 results. There may be more than 50 datasets, so increase
+    // maxResults to make
+    // sure we get all datasets.
+    DatasetList fetchedDatasets =
+        bigQueryCow.datasets().list(projectId).setMaxResults(1000L).execute();
+
     // Because this project has been used for testing before, it may have other datasets lying
     // around waiting for cleanup.
     assertTrue(fetchedDatasets.getDatasets().size() >= 2);

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -11,7 +11,7 @@ dependencies {
   constraints {
     api group: 'bio.terra.cloud-resource-lib', name: 'common', version: '0.11.0'
     api group: 'bio.terra.cloud-resource-lib', name: 'google-api-services-common', version: '0.10.0'
-    api group: 'bio.terra.cloud-resource-lib', name: 'google-bigquery', version: '0.12.0'
+    api group: 'bio.terra.cloud-resource-lib', name: 'google-bigquery', version: '0.13.0'
     api group: 'bio.terra.cloud-resource-lib', name: 'google-billing', version: '0.11.0'
     api group: 'bio.terra.cloud-resource-lib', name: 'google-cloudresourcemanager', version: '1.4.0'
     api group: 'bio.terra.cloud-resource-lib', name: 'google-compute', version: '0.13.0'

--- a/platform/gradle.properties
+++ b/platform/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.4.0
+version = 0.5.0


### PR DESCRIPTION
Before this PR, BigQueryCowTest.listDataset() failed 4-10 times out of 10. After this PR, passes 10/10.