### PR TITLE
TOAZ-37 bump final janitor

### DIFF
--- a/azure-resourcemanager-common/gradle.lockfile
+++ b/azure-resourcemanager-common/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.azure.resourcemanager:azure-resourcemanager-resources:2.10.0=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.azure:azure-core-http-netty:1.11.6=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.azure:azure-core-management:1.4.3=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/azure-resourcemanager-common/gradle.lockfile
+++ b/azure-resourcemanager-common/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.6.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.azure.resourcemanager:azure-resourcemanager-resources:2.10.0=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.azure:azure-core-http-netty:1.11.6=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.azure:azure-core-management:1.4.3=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/azure-resourcemanager-compute/gradle.lockfile
+++ b/azure-resourcemanager-compute/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.6.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.azure.resourcemanager:azure-resourcemanager-authorization:2.10.0=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.azure.resourcemanager:azure-resourcemanager-compute:2.10.0=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.azure.resourcemanager:azure-resourcemanager-msi:2.10.0=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/azure-resourcemanager-compute/gradle.lockfile
+++ b/azure-resourcemanager-compute/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.azure.resourcemanager:azure-resourcemanager-authorization:2.10.0=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.azure.resourcemanager:azure-resourcemanager-compute:2.10.0=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.azure.resourcemanager:azure-resourcemanager-msi:2.10.0=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/azure-resourcemanager-compute/gradle.properties
+++ b/azure-resourcemanager-compute/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.3.1
+version = 0.3.0

--- a/azure-resourcemanager-relay/gradle.properties
+++ b/azure-resourcemanager-relay/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.1.0
+version = 0.2.0

--- a/buildSrc/src/main/groovy/terra-cloud-resource-lib.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/terra-cloud-resource-lib.library-conventions.gradle
@@ -37,7 +37,7 @@ configurations {
 
 dependencies {
     ext {
-        janitorclient = '0.6.1-SNAPSHOT'
+        janitorclient = '0.7.0-SNAPSHOT'
     }
     // Google dependencies - make sure we are using -jre and not android and use common bom
     constraints {

--- a/buildSrc/src/main/groovy/terra-cloud-resource-lib.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/terra-cloud-resource-lib.library-conventions.gradle
@@ -37,7 +37,7 @@ configurations {
 
 dependencies {
     ext {
-        janitorclient = '0.7.0-SNAPSHOT'
+        janitorclient = '0.7.1-SNAPSHOT'
     }
     // Google dependencies - make sure we are using -jre and not android and use common bom
     constraints {

--- a/common/gradle.lockfile
+++ b/common/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.6.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/common/gradle.lockfile
+++ b/common/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/common/gradle.properties
+++ b/common/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.11.1
+version = 0.11.0

--- a/google-api-services-common/gradle.lockfile
+++ b/google-api-services-common/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.6.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-api-services-common/gradle.lockfile
+++ b/google-api-services-common/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-api-services-common/gradle.properties
+++ b/google-api-services-common/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.10.1
+version = 0.10.0

--- a/google-bigquery/gradle.lockfile
+++ b/google-bigquery/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.6.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-bigquery/gradle.lockfile
+++ b/google-bigquery/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-bigquery/gradle.properties
+++ b/google-bigquery/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.13.1
+version = 0.13.0

--- a/google-billing/gradle.lockfile
+++ b/google-billing/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.6.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-billing/gradle.lockfile
+++ b/google-billing/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-billing/gradle.properties
+++ b/google-billing/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.11.1
+version = 0.11.0

--- a/google-cloudresourcemanager/gradle.lockfile
+++ b/google-cloudresourcemanager/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.6.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-cloudresourcemanager/gradle.lockfile
+++ b/google-cloudresourcemanager/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-cloudresourcemanager/gradle.properties
+++ b/google-cloudresourcemanager/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 1.4.1
+version = 1.4.0

--- a/google-compute/gradle.lockfile
+++ b/google-compute/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.6.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-compute/gradle.lockfile
+++ b/google-compute/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-compute/gradle.properties
+++ b/google-compute/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.14.1
+version = 0.14.0

--- a/google-dns/gradle.lockfile
+++ b/google-dns/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.6.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-dns/gradle.lockfile
+++ b/google-dns/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-dns/gradle.properties
+++ b/google-dns/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.11.1
+version = 0.11.0

--- a/google-iam/gradle.lockfile
+++ b/google-iam/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.6.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-iam/gradle.lockfile
+++ b/google-iam/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-iam/gradle.properties
+++ b/google-iam/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.11.1
+version = 0.11.0

--- a/google-notebooks/gradle.lockfile
+++ b/google-notebooks/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.6.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-notebooks/gradle.lockfile
+++ b/google-notebooks/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-notebooks/gradle.properties
+++ b/google-notebooks/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.9.1
+version = 0.9.0

--- a/google-serviceusage/gradle.lockfile
+++ b/google-serviceusage/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.6.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-serviceusage/gradle.lockfile
+++ b/google-serviceusage/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-serviceusage/gradle.properties
+++ b/google-serviceusage/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.11.1
+version = 0.11.0

--- a/google-storage/gradle.lockfile
+++ b/google-storage/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.6.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-storage/gradle.lockfile
+++ b/google-storage/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:terra-resource-janitor-client:0.7.0-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+bio.terra:terra-resource-janitor-client:0.7.1-SNAPSHOT=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.12.3=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.12.3=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/google-storage/gradle.properties
+++ b/google-storage/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.14.1
+version = 0.14.0

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     api group: 'bio.terra.cloud-resource-lib', name: 'google-storage', version: '0.14.0'
     api group: 'bio.terra.cloud-resource-lib', name: 'azure-resourcemanager-common', version: '0.4.0'
     api group: 'bio.terra.cloud-resource-lib', name: 'azure-resourcemanager-compute', version: '0.3.0'
-    api group: 'bio.terra.cloud-resource-lib', name: 'azure-resourcemanager-relay', version: '0.1.0'
+    api group: 'bio.terra.cloud-resource-lib', name: 'azure-resourcemanager-relay', version: '0.2.0'
   }
 }
 

--- a/platform/gradle.properties
+++ b/platform/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.7.0
+version = 0.8.0


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-37

* Bump janitor to the version that has https://github.com/DataBiosphere/terra-resource-janitor/pull/127
* Also reverted the previous PR that bumped all modules's patch version
* Bump Relay verison so that the new version uses new janitor

