### PR TITLE
[TOAZ-71] Remove region field for CreateRelayHybridConnectionRequestData

### DIFF
--- a/azure-resourcemanager-relay/gradle.properties
+++ b/azure-resourcemanager-relay/gradle.properties
@@ -1,3 +1,3 @@
 # Please update platform to consume version updates, see here for more:
 # https://github.com/DataBiosphere/terra-cloud-resource-lib#publishing-an-update
-version = 0.2.0
+version = 0.3.0

--- a/azure-resourcemanager-relay/src/main/java/bio/terra/cloudres/azure/resourcemanager/relay/data/BaseRelayRequestData.java
+++ b/azure-resourcemanager-relay/src/main/java/bio/terra/cloudres/azure/resourcemanager/relay/data/BaseRelayRequestData.java
@@ -12,9 +12,6 @@ public abstract class BaseRelayRequestData implements ResourceManagerRequestData
   /** The name of the resource. */
   public abstract String name();
 
-  /** The region of the resource. */
-  public abstract Region region();
-
   /** The tenant of the resource. */
   public abstract String tenantId();
 
@@ -34,7 +31,6 @@ public abstract class BaseRelayRequestData implements ResourceManagerRequestData
     requestData.addProperty("subscriptionId", subscriptionId());
     requestData.addProperty("resourceGroupName", resourceGroupName());
     requestData.addProperty("name", name());
-    requestData.addProperty("region", region().name());
     return requestData;
   }
 }

--- a/azure-resourcemanager-relay/src/main/java/bio/terra/cloudres/azure/resourcemanager/relay/data/CreateRelayHybridConnectionRequestData.java
+++ b/azure-resourcemanager-relay/src/main/java/bio/terra/cloudres/azure/resourcemanager/relay/data/CreateRelayHybridConnectionRequestData.java
@@ -6,9 +6,9 @@ import bio.terra.cloudres.common.CloudOperation;
 import bio.terra.janitor.model.AzureRelayHybridConnection;
 import bio.terra.janitor.model.AzureResourceGroup;
 import bio.terra.janitor.model.CloudResourceUid;
-import com.azure.core.management.Region;
 import com.google.auto.value.AutoValue;
 import com.google.gson.JsonObject;
+
 import java.util.Optional;
 
 /**
@@ -44,8 +44,6 @@ public abstract class CreateRelayHybridConnectionRequestData extends BaseRelayRe
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract CreateRelayHybridConnectionRequestData.Builder setName(String value);
-
-    public abstract CreateRelayHybridConnectionRequestData.Builder setRegion(Region value);
 
     public abstract CreateRelayHybridConnectionRequestData.Builder setTenantId(String value);
 

--- a/azure-resourcemanager-relay/src/main/java/bio/terra/cloudres/azure/resourcemanager/relay/data/CreateRelayRequestData.java
+++ b/azure-resourcemanager-relay/src/main/java/bio/terra/cloudres/azure/resourcemanager/relay/data/CreateRelayRequestData.java
@@ -18,6 +18,9 @@ import java.util.Optional;
 @AutoValue
 public abstract class CreateRelayRequestData extends BaseRelayRequestData {
 
+  /** The region of the resource. */
+  public abstract Region region();
+
   @Override
   public final CloudOperation cloudOperation() {
     return RelayManagerOperation.AZURE_CREATE_RELAY;
@@ -59,6 +62,7 @@ public abstract class CreateRelayRequestData extends BaseRelayRequestData {
   @Override
   public JsonObject serialize() {
     JsonObject requestData = super.serializeCommon();
+    requestData.addProperty("region", region().name());
     return requestData;
   }
 }

--- a/platform/gradle.properties
+++ b/platform/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.9.1
+version = 0.10.0


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-71

region isn't required for hybrid connectioin since it lives inside a namespace, which is already region specific