### PR TITLE
[PF-722] Require manual publish, stating artifact names

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,14 @@ name: Publish package to Artifactory
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      publications:
+        description: >
+          Comma-separated list of subprojects to be published. Each one should have its version bumped;
+          i.e. we can't publish already-published artifacts. `platform` should always be included.
+        type: string
+        required: true
 env:
   VAULT_ADDR: https://clotho.broadinstitute.org:8200
   ARTIFACTORY_ACCOUNT_PATH: secret/dsp/accts/artifactory/dsdejenkins
@@ -62,3 +70,4 @@ jobs:
           ARTIFACTORY_USERNAME: ${{ steps.vault-secret-step.outputs.artifactory-username }}
           ARTIFACTORY_PASSWORD: ${{ steps.vault-secret-step.outputs.artifactory-password }}
           ARTIFACTORY_REPO_KEY: libs-release-local
+          ARTIFACTORY_PUBLICATIONS: ${{ github.event.inputs.publications }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.util.stream.Collectors
+
 plugins {
     id 'idea'
     id 'maven-publish'
@@ -8,11 +10,19 @@ plugins {
 def artifactory_repo_key = System.getenv("ARTIFACTORY_REPO_KEY") != null ? System.getenv("ARTIFACTORY_REPO_KEY") : 'libs-snapshot-local'
 def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
 def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')
+def artifactory_publications = System.getenv('ARTIFACTORY_PUBLICATIONS') == null
+        ? null
+        : Arrays.stream(System.getenv('ARTIFACTORY_PASSWORD').split(","))
+            .map({s -> s.trim()})
+            .collect(Collectors.toList())
 
 gradle.taskGraph.whenReady { taskGraph ->
     if (taskGraph.hasTask(artifactoryPublish) &&
-            (artifactory_username == null || artifactory_password == null)) {
-        throw new GradleException("Set env vars ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD to publish")
+            (artifactory_username == null
+                    || artifactory_password == null
+                    || artifactory_publications == null)) {
+        throw new GradleException("Set env vars ARTIFACTORY_USERNAME, ARTIFACTORY_PASSWORD,"
+                + " and ARTIFACTORY_PUBLICATIONS to publish")
     }
 }
 
@@ -25,23 +35,7 @@ artifactory {
             password = "${artifactory_password}"
         }
         defaults {
-            publications(
-                    'common',
-                    'google-api-services-common',
-                    'google-bigquery',
-                    'google-billing',
-                    'google-cloudresourcemanager',
-                    'google-compute',
-                    'google-dns',
-                    'google-iam',
-                    'google-notebooks',
-                    'google-serviceusage',
-                    'google-storage',
-                    'platform',
-                    'azure-resourcemanager-common',
-                    'azure-resourcemanager-compute',
-                    'azure-resourcemanager-containerinstance',
-                    'azure-resourcemanager-relay')
+            publications(artifactory_publications)
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'idea'
     id 'maven-publish'
 
-    id 'com.jfrog.artifactory' version '4.13.0'
+    id 'com.jfrog.artifactory' version '4.27.1'
 }
 
 def artifactory_repo_key = System.getenv("ARTIFACTORY_REPO_KEY") != null ? System.getenv("ARTIFACTORY_REPO_KEY") : 'libs-snapshot-local'


### PR DESCRIPTION
To avoid the problem of re-publishing already-published artifact versions (and failing due to overwrite protection), introduce a string input and `workflow_dispatch` trigger to take all and only the artifacts to be published. It's expected that `platform` will be included every time (though not currently enforced).