### PR TITLE
[PF-722] attempt to get publishing again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,10 +158,10 @@ test.dependsOn minniekenny
 
 publishing {
     publications {
-        "$project.name"(MavenPublication) {
-            groupId project.group
-            artifactId project.name
-            version project.version
+        "$rootProject.name"(MavenPublication) {
+            groupId group
+            artifactId rootProject.name
+            version version
             from components.java
             suppressPomMetadataWarningsFor('testFixturesApiElements')
             suppressPomMetadataWarningsFor('testFixturesApiRuntimeElements')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+version = '1.0.0-alpha1'
+group = 'bio.terra'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'terra-cloud-resource-lib'
+


### PR DESCRIPTION
Now that CRL is consolidated, I need to update the publishing instructions. This is a little bit of guesswork on my part, and I haven't RT'd all the FMs yet. My thinking is I can merge this, create a release with the `1.0.0-alpha1` tag, and see what happens.