### PR TITLE
cache the build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching=true


### PR DESCRIPTION
This took a `clean build` after a previous `clean build` down to [2 seconds](https://gradle.com/s/gxxm7atf2erwo). The build is good about not rebuilding things that don't need it, but maybe the caching will help more as the repo grows in size or complexity.