### PR TITLE
[no ticket] Bump bumper to 0.0.6

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -70,7 +70,7 @@ jobs:
           event-name: ${{ github.event_name }}
       - name: Bump the tag to a new version
         if: steps.skiptest.outputs.is-bump == 'no'
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.5
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
         id: tag
         env:
           DEFAULT_BUMP: patch

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -68,8 +68,6 @@ jobs:
         uses: ./.github/actions/bump-skip
         with:
           event-name: ${{ github.event_name }}
-      - name: set-safe-directory
-        run: git config --global --add safe.directory /github/workspace
       - name: Bump the tag to a new version
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -68,6 +68,8 @@ jobs:
         uses: ./.github/actions/bump-skip
         with:
           event-name: ${{ github.event_name }}
+      - name: set-safe-directory
+        run: git config --global --add safe.directory /github/workspace
       - name: Bump the tag to a new version
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6


### PR DESCRIPTION
To fix error: `fatal: unsafe repository ('/github/workspace' is owned by someone else)`