### PR TITLE
[PF-1731] Replace Java setup action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,9 +77,10 @@ jobs:
           integration.azure.admin.tenantId=${AZURE_MANAGED_APP_TENANT_ID}
           EOF
       - name: Set up AdoptOpenJDK 11
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       # See https://github.com/actions/cache/blob/main/examples.md#java---gradle
       - name: Cache Gradle packages
         uses: actions/cache@v2

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -83,9 +83,10 @@ jobs:
           VERSION_SUFFIX: SNAPSHOT
       - name: Set up AdoptOpenJDK
         if: steps.skiptest.outputs.is-bump == 'no'
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       - name: Cache Gradle packages
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: actions/cache@v2


### PR DESCRIPTION
The `joschi/setup-jdk@v2` Github action is deprecated and the recommendation is to move to the official github setup-java action with the `temurin` distribution: see https://github.com/joschi/setup-jdk#-notice