### PR TITLE
[WOR-714] add CloudBillingClient#testIamPermissions

### DIFF
--- a/src/main/java/bio/terra/cloudres/google/billing/CloudBillingClientCow.java
+++ b/src/main/java/bio/terra/cloudres/google/billing/CloudBillingClientCow.java
@@ -9,7 +9,10 @@ import com.google.cloud.billing.v1.CloudBillingSettings;
 import com.google.cloud.billing.v1.ProjectBillingInfo;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,6 +61,14 @@ public class CloudBillingClientCow implements AutoCloseable {
         () -> serialize(name, projectBillingInfo));
   }
 
+  /** See {@link CloudBillingClient#testIamPermissions(TestIamPermissionsRequest)} */
+  public TestIamPermissionsResponse testIamPermissions(TestIamPermissionsRequest request) {
+    return operationAnnotator.executeCowOperation(
+        CloudBillingOperation.GOOGLE_TEST_IAM_PERMISSIONS,
+        () -> billing.testIamPermissions(request),
+        () -> serializeTestIamPermissions(request));
+  }
+
   @VisibleForTesting
   static JsonObject serializeProjectName(String name) {
     JsonObject result = new JsonObject();
@@ -69,6 +80,16 @@ public class CloudBillingClientCow implements AutoCloseable {
   static JsonObject serialize(String projectName, ProjectBillingInfo projectBillingInfo) {
     JsonObject result = serializeProjectName(projectName);
     result.add("project_billing_info", new Gson().toJsonTree(projectBillingInfo));
+    return result;
+  }
+
+  @VisibleForTesting
+  static JsonObject serializeTestIamPermissions(TestIamPermissionsRequest request) {
+    JsonObject result = new JsonObject();
+    result.addProperty("resource", request.getResource());
+    JsonArray permissions = new JsonArray();
+    request.getPermissionsList().forEach(permissions::add);
+    result.add("permissions", permissions);
     return result;
   }
 

--- a/src/main/java/bio/terra/cloudres/google/billing/CloudBillingOperation.java
+++ b/src/main/java/bio/terra/cloudres/google/billing/CloudBillingOperation.java
@@ -6,4 +6,5 @@ import bio.terra.cloudres.common.CloudOperation;
 public enum CloudBillingOperation implements CloudOperation {
   GOOGLE_GET_PROJECT_BILLING,
   GOOGLE_UPDATE_PROJECT_BILLING,
+  GOOGLE_TEST_IAM_PERMISSIONS
 }

--- a/src/test/java/bio/terra/cloudres/google/billing/CloudBillingClientCowTest.java
+++ b/src/test/java/bio/terra/cloudres/google/billing/CloudBillingClientCowTest.java
@@ -55,23 +55,16 @@ public class CloudBillingClientCowTest {
 
   @Test
   public void testIamPermissions() throws Exception {
-    Project project = ProjectUtils.executeCreateProject();
     try (CloudBillingClientCow billingCow = defaultBillingCow()) {
-      ProjectBillingInfo setBilling =
-          ProjectBillingInfo.newBuilder().setBillingAccountName(BILLING_ACCOUNT_NAME).build();
-      ProjectBillingInfo updatedBilling =
-          billingCow.updateProjectBillingInfo("projects/" + project.getProjectId(), setBilling);
       var permissions = List.of("billing.resourceAssociations.create");
       var request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(updatedBilling.getBillingAccountName())
+              .setResource(BILLING_ACCOUNT_NAME)
               .addAllPermissions(permissions)
               .build();
       var response = billingCow.testIamPermissions(request);
       assertEquals(permissions, response.getPermissionsList());
     }
-
-    ProjectUtils.getManagerCow().projects().delete(project.getProjectId());
   }
 
   @Test

--- a/src/test/java/bio/terra/cloudres/google/billing/CloudBillingClientCowTest.java
+++ b/src/test/java/bio/terra/cloudres/google/billing/CloudBillingClientCowTest.java
@@ -57,12 +57,14 @@ public class CloudBillingClientCowTest {
   public void testIamPermissions() throws Exception {
     Project project = ProjectUtils.executeCreateProject();
     try (CloudBillingClientCow billingCow = defaultBillingCow()) {
-      ProjectBillingInfo initialBilling =
-          billingCow.getProjectBillingInfo("projects/" + project.getProjectId());
+      ProjectBillingInfo setBilling =
+          ProjectBillingInfo.newBuilder().setBillingAccountName(BILLING_ACCOUNT_NAME).build();
+      ProjectBillingInfo updatedBilling =
+          billingCow.updateProjectBillingInfo("projects/" + project.getProjectId(), setBilling);
       var permissions = List.of("billing.resourceAssociations.create");
       var request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(initialBilling.getBillingAccountName())
+              .setResource(updatedBilling.getBillingAccountName())
               .addAllPermissions(permissions)
               .build();
       var response = billingCow.testIamPermissions(request);

--- a/src/test/java/bio/terra/cloudres/google/billing/CloudBillingClientCowTest.java
+++ b/src/test/java/bio/terra/cloudres/google/billing/CloudBillingClientCowTest.java
@@ -9,8 +9,10 @@ import bio.terra.cloudres.testing.IntegrationCredentials;
 import bio.terra.cloudres.testing.IntegrationUtils;
 import com.google.api.services.cloudresourcemanager.v3.model.Project;
 import com.google.cloud.billing.v1.ProjectBillingInfo;
+import com.google.iam.v1.TestIamPermissionsRequest;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +54,25 @@ public class CloudBillingClientCowTest {
   }
 
   @Test
+  public void testIamPermissions() throws Exception {
+    Project project = ProjectUtils.executeCreateProject();
+    try (CloudBillingClientCow billingCow = defaultBillingCow()) {
+      ProjectBillingInfo initialBilling =
+          billingCow.getProjectBillingInfo("projects/" + project.getProjectId());
+      var permissions = List.of("billing.resourceAssociations.create");
+      var request =
+          TestIamPermissionsRequest.newBuilder()
+              .setResource(initialBilling.getBillingAccountName())
+              .addAllPermissions(permissions)
+              .build();
+      var response = billingCow.testIamPermissions(request);
+      assertEquals(permissions, response.getPermissionsList());
+    }
+
+    ProjectUtils.getManagerCow().projects().delete(project.getProjectId());
+  }
+
+  @Test
   public void serializeProjectName() {
     assertEquals(
         "{\"project_name\":\"projects/my-project\"}",
@@ -71,6 +92,19 @@ public class CloudBillingClientCowTest {
                 ProjectBillingInfo.newBuilder()
                     .setProjectId("my-project")
                     .setBillingAccountName(BILLING_ACCOUNT_NAME)
+                    .build())
+            .toString());
+  }
+
+  @Test
+  public void serializeTestIamPermissions() {
+    assertEquals(
+        "{\"resource\":\"billingAccounts/01A82E-CA8A14-367457\","
+            + "\"permissions\":[\"billing.resourceAssociations.create\"]}",
+        CloudBillingClientCow.serializeTestIamPermissions(
+                TestIamPermissionsRequest.newBuilder()
+                    .setResource("billingAccounts/01A82E-CA8A14-367457")
+                    .addPermissions("billing.resourceAssociations.create")
                     .build())
             .toString());
   }


### PR DESCRIPTION
Ticket: [WOR-714](https://broadworkbench.atlassian.net/browse/WOR-714)
BPM is using a snapshot from an [unmerged version of CRL](https://github.com/DataBiosphere/terra-cloud-resource-lib/pull/109). The unmerged PR was somewhat out of date wrt file organization. All I've done is cherry-pick the commits from the original PR onto the HEAD of the master branch and fix up the test. When this is merged, we'll update BPM to use the new version of CRL.

[WOR-714]: https://broadworkbench.atlassian.net/browse/WOR-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ