### PR TITLE
[TERRA-434] Replace deprecated commands in GH actions & workflows

### DIFF
--- a/.github/actions/bump-skip/action.yml
+++ b/.github/actions/bump-skip/action.yml
@@ -25,5 +25,5 @@ runs:
           IS_BUMP=yes
         fi
         echo "IS_BUMP=$IS_BUMP"
-        echo ::set-output name=is-bump::$IS_BUMP
+        echo is-bump=$IS_BUMP >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Pull Vault image
         run: docker pull vault:1.1.0
       # Currently, there's no way to add capabilities to Docker actions on Git, and Vault needs IPC_LOCK to run.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -88,7 +88,7 @@ jobs:
           java-version: 17
       # See https://github.com/actions/cache/blob/main/examples.md#java---gradle
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -105,7 +105,7 @@ jobs:
         run: ./gradlew integrationTest --scan
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Test Reports
           path: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
               auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
               secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
           echo ::add-mask::$VAULT_TOKEN
-          echo ::set-output name=vault-token::$VAULT_TOKEN
+          echo vault-token=$VAULT_TOKEN >> $GITHUB_OUTPUT
       - name: Get service account credentials from Vault
         id: vault-secret-step
         run: |

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -88,7 +88,7 @@ jobs:
           java-version: 17
       - name: Cache Gradle packages
         if: steps.skiptest.outputs.is-bump == 'no'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -58,7 +58,7 @@ jobs:
           echo ::set-output name=semver-part::$SEMVER_PART
           echo ::set-output name=checkout-branch::$CHECKOUT_BRANCH
       - name: Checkout current code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ steps.controls.outputs.checkout-branch }}
           token: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -55,8 +55,8 @@ jobs:
             SEMVER_PART=${{ github.event.inputs.bump }}
             CHECKOUT_BRANCH=${{ github.event.inputs.branch }}
           fi
-          echo ::set-output name=semver-part::$SEMVER_PART
-          echo ::set-output name=checkout-branch::$CHECKOUT_BRANCH
+          echo semver-part=$SEMVER_PART >> $GITHUB_OUTPUT
+          echo checkout-branch=$CHECKOUT_BRANCH >> $GITHUB_OUTPUT
       - name: Checkout current code
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Replace deprecated commands in GH actions & workflows.

- use actions/setup-java@v3 instead of v2
- use actions/checkout@v3 instead of v2
- replace 'set-output' command