### PR TITLE
[PF-1258] Add retries for 500 responses from GCP

### DIFF
--- a/src/main/java/bio/terra/cloudres/common/OperationAnnotator.java
+++ b/src/main/java/bio/terra/cloudres/common/OperationAnnotator.java
@@ -94,8 +94,8 @@ public class OperationAnnotator {
         }
       }
     } finally {
-      // Record operation and close the span exactly once, regardless of how many times the operation
-      // was retried.
+      // Record operation and close the span exactly once, regardless of how many times the
+      // operation was retried.
       recordOperation(
           OperationData.builder()
               .setCloudOperation(cloudOperation)

--- a/src/test/java/bio/terra/cloudres/common/OperationAnnotatorTest.java
+++ b/src/test/java/bio/terra/cloudres/common/OperationAnnotatorTest.java
@@ -54,18 +54,20 @@ public class OperationAnnotatorTest {
         }
       };
 
-  private final OperationAnnotator.CowExecute<?> RETRIABLE_COW_EXECUTE = new OperationAnnotator.CowExecute<Void>() {
-    int retryCount = 0;
-    @Override
-    public Void execute() {
-      if (retryCount == OperationAnnotator.MAX_RETRIES) {
-        return null;
-      } else {
-        retryCount += 1;
-        throw new ResourceManagerException(500, ERROR_MESSAGE);
-      }
-    }
-  };
+  private final OperationAnnotator.CowExecute<?> RETRIABLE_COW_EXECUTE =
+      new OperationAnnotator.CowExecute<Void>() {
+        int retryCount = 0;
+
+        @Override
+        public Void execute() {
+          if (retryCount == OperationAnnotator.MAX_RETRIES) {
+            return null;
+          } else {
+            retryCount += 1;
+            throw new ResourceManagerException(500, ERROR_MESSAGE);
+          }
+        }
+      };
 
   private static final OperationAnnotator.CowExecute<?> SERVER_ERROR_RESPONSE_COW_EXECUTE =
       () -> {
@@ -309,11 +311,13 @@ public class OperationAnnotatorTest {
     operationAnnotator = new OperationAnnotator(clientConfig, mockLogger);
     Assert.assertThrows(
         ResourceManagerException.class,
-        () -> operationAnnotator.executeCowOperation(
-        StubCloudOperation.TEST_OPERATION, SERVER_ERROR_RESPONSE_COW_EXECUTE, SERIALIZE));
+        () ->
+            operationAnnotator.executeCowOperation(
+                StubCloudOperation.TEST_OPERATION, SERVER_ERROR_RESPONSE_COW_EXECUTE, SERIALIZE));
 
     // Validate the logged response has tryCount set
-    verify(mockLogger).debug(any(), gsonArgumentCaptor.capture(), exceptionArgumentCaptor.capture());
+    verify(mockLogger)
+        .debug(any(), gsonArgumentCaptor.capture(), exceptionArgumentCaptor.capture());
     JsonObject json = gsonArgumentCaptor.getValue();
     assertEquals(json.getAsJsonPrimitive("tryCount").getAsInt(), OperationAnnotator.MAX_RETRIES);
 

--- a/src/testFixtures/java/bio/terra/cloudres/testing/MetricsTestUtil.java
+++ b/src/testFixtures/java/bio/terra/cloudres/testing/MetricsTestUtil.java
@@ -23,6 +23,12 @@ public class MetricsTestUtil {
           TagValue.create(StubCloudOperation.TEST_OPERATION.name()),
           TagValue.create("404"));
 
+  public static final List<TagValue> ERROR_COUNT_500 =
+      Arrays.asList(
+          TagValue.create(CLIENT),
+          TagValue.create(StubCloudOperation.TEST_OPERATION.name()),
+          TagValue.create("500"));
+
   public static final View.Name API_VIEW_NAME =
       View.Name.create(CLOUD_RESOURCE_PREFIX + "/cloud/api");
   public static final View.Name ERROR_VIEW_NAME =


### PR DESCRIPTION
Every now and then we get 500 responses from GCP APIs which cause test failures. These almost always have nondescript error messages like "Internal Error", and retrying them inside CRL saves clients from wrapping the calls and doing it themselves. A few open questions:

- Should we log retried calls once, or once-per-retry? For Azure we log once (since it seems like the underlying libraries handle retries) so I copied that approach here, but either seems reasonable.
- Should we retry any other errors, e.g. all 5XX responses? I'm leaning towards just 500 for now since that's the most common one we see, but that's probably missing some rare errors.