### PR TITLE
[TERRA-492] Use latest bumper version

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -69,7 +69,7 @@ jobs:
           event-name: ${{ github.event_name }}
       - name: Bump the tag to a new version
         if: steps.skiptest.outputs.is-bump == 'no'
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
         id: tag
         env:
           DEFAULT_BUMP: patch


### PR DESCRIPTION
[TERRA-492] Use latest bumper version - fixes github set-output deprecated warnings