### PR TITLE
Fix publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ plugins {
     id 'org.sonarqube' version '4.0.0.2929'
 }
 
+group = gradle.projectGroup
+
 project.ext {
     isCiServer = System.getenv().containsKey("CI")
 }


### PR DESCRIPTION
The builds since `1.2.10` have been broken with the error 
```
 Could not parse module metadata https://broadinstitute.jfrog.io/broadinstitute/...:
  - missing 'group' at /variants[2]/capabilities[0]
```
when attempting to use the libraries in other services.
I tested this by publishing a throwaway version (`0.0.0-ZLOERY-1.2.12-SNAPSHOT`) which I could use successfully.