### PR TITLE
[PF-2630] Specify platform for api dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ dependencies {
     api group: 'com.google.cloud', name: 'google-cloud-billing'
     api group: 'com.google.cloud', name: 'google-cloud-core-http'
     api group: 'com.google.cloud', name: 'google-cloud-storage'
-    api group: 'com.google.guava', name: 'guava'
     api group: 'com.google.apis', name: 'google-api-services-bigquery', version: 'v2-rev20220716-1.32.1'
     api group: 'com.google.apis', name: 'google-api-services-cloudresourcemanager', version: 'v3-rev20220710-1.32.1'
     api group: 'com.google.apis', name: 'google-api-services-compute', version: 'v1-rev20220720-1.32.1'
@@ -63,6 +62,7 @@ dependencies {
     api group: 'com.google.apis', name: 'google-api-services-notebooks', version: 'v1-rev20220716-1.32.1'
     api group: 'com.google.apis', name: 'google-api-services-serviceusage', version: 'v1beta1-rev20220615-1.32.1'
     api group: 'com.google.auth', name: 'google-auth-library-oauth2-http'
+    api group: 'com.google.guava', name: 'guava'
     testFixturesImplementation platform('com.google.cloud:libraries-bom:26.0.0')
     testImplementation group: 'com.google.cloud', name: 'google-cloud-resourcemanager'
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,11 @@ dependencies {
     }
     implementation platform('com.google.cloud:libraries-bom:26.0.0') // use common bom
     implementation group: 'com.google.cloud', name: 'google-cloud-pubsub'
+    api platform('com.google.cloud:libraries-bom:26.0.0')
+    api group: 'com.google.cloud', name: 'google-cloud-billing'
+    api group: 'com.google.cloud', name: 'google-cloud-core-http'
+    api group: 'com.google.cloud', name: 'google-cloud-storage'
+    api group: 'com.google.guava', name: 'guava'
     api group: 'com.google.apis', name: 'google-api-services-bigquery', version: 'v2-rev20220716-1.32.1'
     api group: 'com.google.apis', name: 'google-api-services-cloudresourcemanager', version: 'v3-rev20220710-1.32.1'
     api group: 'com.google.apis', name: 'google-api-services-compute', version: 'v1-rev20220720-1.32.1'
@@ -58,10 +63,7 @@ dependencies {
     api group: 'com.google.apis', name: 'google-api-services-notebooks', version: 'v1-rev20220716-1.32.1'
     api group: 'com.google.apis', name: 'google-api-services-serviceusage', version: 'v1beta1-rev20220615-1.32.1'
     api group: 'com.google.auth', name: 'google-auth-library-oauth2-http'
-    api group: 'com.google.cloud', name: 'google-cloud-billing'
-    api group: 'com.google.cloud', name: 'google-cloud-core-http'
-    api group: 'com.google.cloud', name: 'google-cloud-storage'
-    api group: 'com.google.guava', name: 'guava'
+
     testFixturesImplementation platform('com.google.cloud:libraries-bom:26.0.0')
     testImplementation group: 'com.google.cloud', name: 'google-cloud-resourcemanager'
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ dependencies {
     api group: 'com.google.apis', name: 'google-api-services-notebooks', version: 'v1-rev20220716-1.32.1'
     api group: 'com.google.apis', name: 'google-api-services-serviceusage', version: 'v1beta1-rev20220615-1.32.1'
     api group: 'com.google.auth', name: 'google-auth-library-oauth2-http'
-
     testFixturesImplementation platform('com.google.cloud:libraries-bom:26.0.0')
     testImplementation group: 'com.google.cloud', name: 'google-cloud-resourcemanager'
 


### PR DESCRIPTION
Previously, we did not specify the platform or version number for several exported dependencies. As a result, clients which used CRL but did not pull in the GCP libraries BOM on their own (like RBS) would fail to properly resolve dependencies. This does not add any additional dependencies (so it has no lockfile changes).

Tested locally and with a throwaway published image using RBS dependencies