### PR TITLE
[TERRA-498] Add folderExists and deleteFolder to s3BucketCow, surface errors

### DIFF
--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -35,4 +35,4 @@ task minniekenny(type: Exec) {
     commandLine 'sh', file('minnie-kenny.sh')
 }
 
-//test.dependsOn minniekenny
+test.dependsOn minniekenny

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -35,4 +35,4 @@ task minniekenny(type: Exec) {
     commandLine 'sh', file('minnie-kenny.sh')
 }
 
-test.dependsOn minniekenny
+//test.dependsOn minniekenny

--- a/src/main/java/bio/terra/cloudres/aws/bucket/S3BucketCow.java
+++ b/src/main/java/bio/terra/cloudres/aws/bucket/S3BucketCow.java
@@ -3,21 +3,33 @@ package bio.terra.cloudres.aws.bucket;
 import bio.terra.cloudres.common.ClientConfig;
 import bio.terra.cloudres.common.OperationAnnotator;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
 import com.google.gson.JsonObject;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Delete;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.Tag;
+import software.amazon.awssdk.services.s3.model.Tagging;
 
 /**
  * A Cloud Object Wrapper(COW) for AWS S3 Bucket Library: {@link S3Client}. Generally, this should
@@ -29,6 +41,7 @@ public class S3BucketCow implements AutoCloseable {
   private static Logger logger = LoggerFactory.getLogger(S3BucketCow.class);
   private final OperationAnnotator operationAnnotator;
   private final S3Client bucketClient;
+  public static final int MAX_RESULTS_PER_REQUEST_S3 = 1000;
 
   @VisibleForTesting
   public static void setLogger(Logger newLogger) {
@@ -53,26 +66,37 @@ public class S3BucketCow implements AutoCloseable {
 
   /**
    * In AWS, objects are really stored in a flat structure. However, they are displayed as if they
-   * have a folder structure. Folders are really 0 byte objects with a path ending in "/". This is a
-   * convenient wrapper around {@link #putBlob} for creating empty objects.
+   * have a folder structure. Folders are really 0 byte objects with a path ending in "/", or they
+   * may not actually exist (e.g. the existence of a file named /foo/bar/file.txt does not mean a 0
+   * byte /foo/bar/ object exists).
+   *
+   * <p>This is a convenient wrapper around {@link #putBlob} for creating empty objects.
    */
-  public void createFolder(String bucketName, String objPath) {
+  public void createFolder(String bucketName, String objPath, Collection<Tag> tags)
+      throws AwsServiceException, SdkClientException, S3Exception {
     if (objPath == null || !objPath.endsWith("/")) {
       throw new IllegalArgumentException("S3 folder paths must end in a / character.");
     }
-    putBlob(bucketName, objPath, RequestBody.fromString(""));
+    putBlob(bucketName, objPath, tags, RequestBody.fromString(""));
   }
 
-  public void putBlob(String bucketName, String objPath, RequestBody contents) {
-    operationAnnotator.executeCowOperation(
+  public void putBlob(String bucketName, String objPath, Collection<Tag> tags, RequestBody contents)
+      throws AwsServiceException, SdkClientException, S3Exception {
+    operationAnnotator.executeCheckedCowOperation(
         S3BucketOperation.AWS_CREATE_S3_OBJECT,
         () ->
             bucketClient.putObject(
-                PutObjectRequest.builder().bucket(bucketName).key(objPath).build(), contents),
-        () -> serialize(bucketName, objPath, contents));
+                PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .tagging(Tagging.builder().tagSet(tags).build())
+                    .key(objPath)
+                    .build(),
+                contents),
+        () -> serialize(bucketName, objPath, tags, contents));
   }
 
-  public void deleteBlob(String bucketName, String objectPath) {
+  public void deleteBlob(String bucketName, String objectPath)
+      throws AwsServiceException, SdkClientException, S3Exception {
     operationAnnotator.executeCowOperation(
         S3BucketOperation.AWS_DELETE_S3_OBJECT,
         () ->
@@ -81,7 +105,35 @@ public class S3BucketCow implements AutoCloseable {
         () -> serialize(bucketName, objectPath));
   }
 
-  public GetObjectResponse getBlob(String bucketName, String objectPath) throws IOException {
+  /**
+   * Delete all objects in an AWS bucket with a common prefix. Because AWS can only support up to
+   * 1000 object deletions from a single request, this method may make multiple calls to AWS
+   * infrastructure, each of which will be logged separately.
+   */
+  public void deleteFolder(String bucketName, String prefix)
+      throws AwsServiceException, SdkClientException, S3Exception {
+    String folderKey = prefix.endsWith("/") ? prefix : String.format("%s/", prefix);
+    List<ObjectIdentifier> fullObjectList =
+        listBlobs(bucketName, folderKey).contents().stream()
+            .map(o -> ObjectIdentifier.builder().key(o.key()).build())
+            .collect(Collectors.toList());
+    Lists.partition(fullObjectList, MAX_RESULTS_PER_REQUEST_S3)
+        .forEach(
+            partitionedObjectList -> {
+              operationAnnotator.executeCowOperation(
+                  S3BucketOperation.AWS_DELETE_S3_FOLDER,
+                  () ->
+                      bucketClient.deleteObjects(
+                          DeleteObjectsRequest.builder()
+                              .bucket(bucketName)
+                              .delete(Delete.builder().objects(partitionedObjectList).build())
+                              .build()),
+                  () -> serialize(bucketName, folderKey));
+            });
+  }
+
+  public GetObjectResponse getBlob(String bucketName, String objectPath)
+      throws IOException, AwsServiceException, SdkClientException, S3Exception {
     // try-with-resources because getObject returns a stream which we must close.
     try (ResponseInputStream<GetObjectResponse> response =
         operationAnnotator.executeCowOperation(
@@ -94,13 +146,14 @@ public class S3BucketCow implements AutoCloseable {
     }
   }
 
-  public ListObjectsV2Response listBlobs(String bucketName, String prefix) {
+  public ListObjectsV2Response listBlobs(String bucketName, String prefix)
+      throws AwsServiceException, SdkClientException, S3Exception {
     // A null continuationToken is ignored by the AWS client
     return listBlobs(bucketName, prefix, /*continuationToken=*/ null);
   }
 
-  public ListObjectsV2Response listBlobs(
-      String bucketName, String prefix, String continuationToken) {
+  public ListObjectsV2Response listBlobs(String bucketName, String prefix, String continuationToken)
+      throws AwsServiceException, SdkClientException, S3Exception {
     return operationAnnotator.executeCowOperation(
         S3BucketOperation.AWS_LIST_S3_OBJECTS,
         () ->
@@ -114,15 +167,39 @@ public class S3BucketCow implements AutoCloseable {
   }
 
   /**
+   * In AWS, objects are really stored in a flat structure. However, they are displayed as if they
+   * have a folder structure. Folders are really 0 byte objects with a path ending in "/", or they
+   * may not actually exist (e.g. the existence of a file named /foo/bar/file.txt does not mean a 0
+   * byte /foo/bar/ object exists).
+   *
+   * <p>This is a convenient wrapper around {@link #listBlobs} checking if any object names begin
+   * with a particular prefix.
+   *
+   * @param bucketName The name of the bucket to query
+   * @param folderPath The folder string to check for. This must be the full path from the top-level
+   *     of the bucket, it cannot be a partial path.
+   */
+  public boolean folderExists(String bucketName, String folderPath)
+      throws AwsServiceException, SdkClientException, S3Exception {
+    String folderKey = folderPath.endsWith("/") ? folderPath : String.format("%s/", folderPath);
+    return listBlobs(bucketName, folderKey).contents().size() > 0;
+  }
+
+  /**
    * Serialize several fields into a useful JSON object for logging with TCL. Note that this does
    * not log the entire request body, which could contain a large amount of data. Instead, this only
    * logs the content length.
    */
   @VisibleForTesting
-  public JsonObject serialize(String bucketName, String pathPrefix, RequestBody contents) {
+  public JsonObject serialize(
+      String bucketName, String pathPrefix, Collection<Tag> tags, RequestBody contents) {
     var ser = new JsonObject();
     ser.addProperty("bucketName", bucketName);
     ser.addProperty("pathPrefix", pathPrefix);
+    // Tags represent key-value pairs, serialize them in the format "k1:v1,k2:v2,..."
+    String serializedTags =
+        tags.stream().map(tag -> tag.key() + ":" + tag.value()).collect(Collectors.joining(","));
+    ser.addProperty("tags", String.join(",", serializedTags));
     // We do not need to log all data that services put in S3 buckets, just log metadata instead.
     ser.addProperty("contentLength", contents.optionalContentLength().orElse(0L));
     return ser;

--- a/src/main/java/bio/terra/cloudres/aws/bucket/S3BucketOperation.java
+++ b/src/main/java/bio/terra/cloudres/aws/bucket/S3BucketOperation.java
@@ -6,5 +6,6 @@ public enum S3BucketOperation implements CloudOperation {
   AWS_LIST_S3_OBJECTS,
   AWS_CREATE_S3_OBJECT,
   AWS_GET_S3_OBJECT,
-  AWS_DELETE_S3_OBJECT
+  AWS_DELETE_S3_OBJECT,
+  AWS_DELETE_S3_FOLDER
 }

--- a/src/test/java/bio/terra/cloudres/aws/bucket/S3BucketCowTest.java
+++ b/src/test/java/bio/terra/cloudres/aws/bucket/S3BucketCowTest.java
@@ -267,6 +267,10 @@ public class S3BucketCowTest {
     ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<JsonObject> gsonArgumentCaptor = ArgumentCaptor.forClass(JsonObject.class);
     String prefixWithoutSlash = "this/path/exists";
+    S3Object fakeObject = mock(S3Object.class);
+    ListObjectsV2Response responseWithObject =
+        ListObjectsV2Response.builder().contents(fakeObject).build();
+    when(mockS3Client.listObjectsV2((ListObjectsV2Request) any())).thenReturn(responseWithObject);
 
     // Verify that prefix is always treated as if it has a trailing /, including for serialization
     assertTrue(bucketCow.folderExists(fakeBucketName, prefixWithoutSlash));


### PR DESCRIPTION
This is a small collection of improvements to the S3BucketCow as we've iterated on adding S3 buckets to WSM. The main changes:

- Add unchecked exceptions from the underlying S3 client to method signatures. This makes it clearer what exceptions these methods will throw in common failure modes
- Add a `folderExists` method as a wrapper around `listBlobs`
- Add a `deleteFolder` method which deletes multiple objects in a single call. This uses a different AWS endpoint, so I'm logging it as a different operation.
- Allow callers to pass tags in during object creation
- Fix `assertEquals` in tests, the expected and actual arguments were swapped.

In addition to the CRL tests, see [example WSM PR](https://github.com/DataBiosphere/terra-workspace-manager/pull/1210) for a preview of how these methods can be used in WSM.