### PR TITLE
[TERRA-507] Add AWS Security Token Service COW

### DIFF
--- a/src/main/java/bio/terra/cloudres/aws/sts/SecurityTokenServiceCow.java
+++ b/src/main/java/bio/terra/cloudres/aws/sts/SecurityTokenServiceCow.java
@@ -1,0 +1,128 @@
+package bio.terra.cloudres.aws.sts;
+
+import bio.terra.cloudres.common.ClientConfig;
+import bio.terra.cloudres.common.OperationAnnotator;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.JsonObject;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+public class SecurityTokenServiceCow implements AutoCloseable {
+
+  public static final int MAX_ROLE_SESSION_NAME_LENGTH = 64;
+  public static final Duration MIN_ROLE_SESSION_TOKEN_DURATION = Duration.ofSeconds(900);
+
+  private static Logger logger = LoggerFactory.getLogger(SecurityTokenServiceCow.class);
+  private final OperationAnnotator operationAnnotator;
+  private final StsClient stsClient;
+
+  @VisibleForTesting
+  public static void setLogger(Logger newLogger) {
+    logger = newLogger;
+  }
+
+  public SecurityTokenServiceCow(ClientConfig clientConfig, StsClient stsClient) {
+    this.operationAnnotator = new OperationAnnotator(clientConfig, logger);
+    this.stsClient = stsClient;
+  }
+
+  /** Create a {@link SecurityTokenServiceCow} with some default configurations for convenience. */
+  public static SecurityTokenServiceCow create(
+      ClientConfig clientConfig, AwsCredentialsProvider awsCredential) {
+    StsClient stsClient =
+        StsClient.builder().credentialsProvider(awsCredential).region(Region.AWS_GLOBAL).build();
+    return new SecurityTokenServiceCow(clientConfig, stsClient);
+  }
+
+  /**
+   * Build a refreshable request body for assuming an AWS role.
+   *
+   * <p>Unlike other operations, this is just a utility for generating a request body. It does not
+   * perform any actual cloud operations. However, this is used by {@code
+   * StsAssumeRoleWithWebIdentityCredentialsProvider} to automatically cache and refresh credentials
+   * as needed. Because CRL cannot log each time the refresh request is used, we just log when the
+   * original request is created.
+   *
+   * @param roleArn ARN of the role to request credentials for
+   * @param duration Total duration these credentials should be valid for. Note this is not the same
+   *     as the duration of a console session created from these credentials - that can be specified
+   *     separately at session creation time.
+   * @param serviceAccountEmail Email of the GCP service account used to assume this role. This is
+   *     used for the human-readable role session name.
+   * @param idToken An OIDC token for the GCP service account used to assume this role via web
+   *     identity federation.
+   * @return A request body to assume the specified role via web identity federation. Note this
+   *     method does not make any calls to STS.
+   */
+  public AssumeRoleWithWebIdentityRequest createRefreshRequest(
+      Arn roleArn, Duration duration, String serviceAccountEmail, String idToken) {
+    String roleSessionName = getRoleSessionName(serviceAccountEmail);
+    return operationAnnotator.executeCowOperation(
+        SecurityTokenServiceOperation.AWS_CREATE_REFRESH_REQUEST,
+        () ->
+            AssumeRoleWithWebIdentityRequest.builder()
+                .roleArn(roleArn.toString())
+                .durationSeconds((int) duration.toSeconds())
+                .roleSessionName(roleSessionName)
+                .webIdentityToken(idToken)
+                .build(),
+        () -> serialize(roleArn, duration, roleSessionName));
+  }
+
+  /**
+   * Call STS to get short-lived credentials for a role.
+   *
+   * <p>This produces a single, non-refreshable credential for the specified role. This is generally
+   * used for WSM to provide user-scoped credentials to callers - for longer-lived service
+   * credentials, prefer using the {@code StsAssumeRoleWithWebIdentityCredentialsProvider} with a
+   * refresh request from {@link #createRefreshRequest(Arn, Duration, String, String)}, which will
+   * automatically cache and refresh credentials to minimize actual calls to STS.
+   *
+   * @param request The request to make to STS
+   * @return A Credentials object containing access and secret keys as well as session token and
+   *     expiration time.
+   */
+  public Credentials assumeRole(AssumeRoleRequest request) {
+    return operationAnnotator.executeCheckedCowOperation(
+        SecurityTokenServiceOperation.AWS_ASSUME_ROLE_WITH_WEB_IDENTITY,
+        () -> stsClient.assumeRole(request).credentials(),
+        () -> serialize(request));
+  }
+
+  private static String getRoleSessionName(String value) {
+    return (value.length() > MAX_ROLE_SESSION_NAME_LENGTH)
+        ? value.substring(0, MAX_ROLE_SESSION_NAME_LENGTH)
+        : value;
+  }
+
+  @VisibleForTesting
+  public JsonObject serialize(Arn roleArn, Duration duration, String serviceAccountEmail) {
+    var ser = new JsonObject();
+    ser.addProperty("roleArn", roleArn.toString());
+    ser.addProperty("duration", duration.toString());
+    ser.addProperty("serviceAccountEmail", serviceAccountEmail);
+    return ser;
+  }
+
+  @VisibleForTesting
+  public JsonObject serialize(AssumeRoleRequest request) {
+    var ser = new JsonObject();
+    // Per AssumeRoleRequest.toString() documentation, sensitive data will be redacted from this
+    // string using a placeholder value.
+    ser.addProperty("request", request.toString());
+    return ser;
+  }
+
+  @Override
+  public void close() throws Exception {
+    stsClient.close();
+  }
+}

--- a/src/main/java/bio/terra/cloudres/aws/sts/SecurityTokenServiceOperation.java
+++ b/src/main/java/bio/terra/cloudres/aws/sts/SecurityTokenServiceOperation.java
@@ -1,0 +1,8 @@
+package bio.terra.cloudres.aws.sts;
+
+import bio.terra.cloudres.common.CloudOperation;
+
+public enum SecurityTokenServiceOperation implements CloudOperation {
+  AWS_ASSUME_ROLE_WITH_WEB_IDENTITY,
+  AWS_CREATE_REFRESH_REQUEST
+}

--- a/src/test/java/bio/terra/cloudres/aws/sts/SecurityTokenServiceCowTest.java
+++ b/src/test/java/bio/terra/cloudres/aws/sts/SecurityTokenServiceCowTest.java
@@ -1,0 +1,104 @@
+package bio.terra.cloudres.aws.sts;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.cloudres.common.ClientConfig;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.slf4j.Logger;
+import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
+import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.utils.StringUtils;
+
+/**
+ * Note: For AWS APIs, we do not significantly modify the API surface, we just decorate with useful
+ * features (currently, logging and metric generation). Unlike GCP APIs, these are entirely unit
+ * tests that validate CRL behavior but do not call out to live AWS environments. Services should
+ * perform connected or integration tests as necessary to validate integration with AWS.
+ */
+@Tag("unit")
+public class SecurityTokenServiceCowTest {
+
+  private SecurityTokenServiceCow stsCow;
+  @Mock private StsClient mockStsClient = mock(StsClient.class);
+  @Mock private Logger mockLogger = mock(Logger.class);
+
+  @BeforeEach
+  public void setupMocks() {
+    ClientConfig unitTestConfig =
+        ClientConfig.Builder.newBuilder().setClient("SecurityTokenServiceCowTest").build();
+    SecurityTokenServiceCow.setLogger(mockLogger);
+    stsCow = new SecurityTokenServiceCow(unitTestConfig, mockStsClient);
+  }
+
+  @Test
+  public void createRefreshRequestTest() {
+    ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<JsonObject> gsonArgumentCaptor = ArgumentCaptor.forClass(JsonObject.class);
+
+    Arn fakeArn = Arn.fromString("arn:this:is:a:fake:value/resource");
+    String serviceAccountEmail = "my-fake-service-account@gserviceaccount.com";
+    String idToken = "real-id-token-trust-me";
+    stsCow.createRefreshRequest(
+        fakeArn,
+        SecurityTokenServiceCow.MIN_ROLE_SESSION_TOKEN_DURATION,
+        serviceAccountEmail,
+        idToken);
+    verify(mockLogger).debug(stringArgumentCaptor.capture(), gsonArgumentCaptor.capture());
+    JsonObject json = gsonArgumentCaptor.getValue();
+    JsonObject serializedRequest =
+        stsCow.serialize(
+            fakeArn, SecurityTokenServiceCow.MIN_ROLE_SESSION_TOKEN_DURATION, serviceAccountEmail);
+    assertEquals(serializedRequest, json.getAsJsonObject("requestData"));
+  }
+
+  @Test
+  public void createRefreshRequestTruncatesSessionName() {
+    Arn fakeArn = Arn.fromString("arn:this:is:a:fake:value/resource");
+    String sessionName =
+        StringUtils.repeat("a", SecurityTokenServiceCow.MAX_ROLE_SESSION_NAME_LENGTH * 2);
+    String idToken = "real-id-token-trust-me";
+    AssumeRoleWithWebIdentityRequest request =
+        stsCow.createRefreshRequest(
+            fakeArn, SecurityTokenServiceCow.MIN_ROLE_SESSION_TOKEN_DURATION, sessionName, idToken);
+    assertEquals(
+        SecurityTokenServiceCow.MAX_ROLE_SESSION_NAME_LENGTH, request.roleSessionName().length());
+  }
+
+  @Test
+  public void assumeRoleTest() {
+    ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<JsonObject> gsonArgumentCaptor = ArgumentCaptor.forClass(JsonObject.class);
+
+    AssumeRoleRequest request =
+        AssumeRoleRequest.builder()
+            .roleArn("arn:this:is:a:fake:value/role")
+            .durationSeconds(
+                (int) SecurityTokenServiceCow.MIN_ROLE_SESSION_TOKEN_DURATION.toSeconds())
+            .roleSessionName("mySessionName")
+            .build();
+
+    Credentials mockCredentials = mock(Credentials.class);
+    AssumeRoleResponse mockResponse = mock(AssumeRoleResponse.class);
+    when(mockResponse.credentials()).thenReturn(mockCredentials);
+    when(mockStsClient.assumeRole((AssumeRoleRequest) any())).thenReturn(mockResponse);
+
+    stsCow.assumeRole(request);
+    verify(mockLogger).debug(stringArgumentCaptor.capture(), gsonArgumentCaptor.capture());
+    JsonObject json = gsonArgumentCaptor.getValue();
+    JsonObject serializedRequest = stsCow.serialize(request);
+    assertEquals(serializedRequest, json.getAsJsonObject("requestData"));
+  }
+}


### PR DESCRIPTION
This wraps the `assumeRoleWithWebIdentity` endpoint as well as a method for creating a  `AssumeRoleWithWebIdentityRequest` object. 

STS is unique in that when using an `StsAssumeRoleWithWebIdentityCredentialsProvider`, we cannot log each cloud call, as the library will automatically handle caching and refreshing credentials. Instead, this method will just log once when the initial refresh request is created which will provide some visibility, though we won't be able to track errors as easily.