### PR TITLE
Add notebook proxy signed URL creation to SageMaker Notebook COW.

### DIFF
--- a/src/main/java/bio/terra/cloudres/aws/notebook/SageMakerNotebookCow.java
+++ b/src/main/java/bio/terra/cloudres/aws/notebook/SageMakerNotebookCow.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sagemaker.SageMakerClient;
 import software.amazon.awssdk.services.sagemaker.model.CreateNotebookInstanceRequest;
 import software.amazon.awssdk.services.sagemaker.model.CreateNotebookInstanceResponse;
+import software.amazon.awssdk.services.sagemaker.model.CreatePresignedNotebookInstanceUrlRequest;
 import software.amazon.awssdk.services.sagemaker.model.DeleteNotebookInstanceRequest;
 import software.amazon.awssdk.services.sagemaker.model.DescribeNotebookInstanceRequest;
 import software.amazon.awssdk.services.sagemaker.model.DescribeNotebookInstanceResponse;
@@ -86,6 +87,19 @@ public class SageMakerNotebookCow implements AutoCloseable {
                     .notebookInstanceName(instanceName)
                     .build()),
         () -> serializeInstanceName(instanceName));
+  }
+
+  public String createPresignedUrl(String instanceName) {
+    return operationAnnotator
+        .executeCowOperation(
+            SageMakerNotebookOperation.AWS_CREATE_PRESIGNED_URL_NOTEBOOK,
+            () ->
+                notebooksClient.createPresignedNotebookInstanceUrl(
+                    CreatePresignedNotebookInstanceUrlRequest.builder()
+                        .notebookInstanceName(instanceName)
+                        .build()),
+            () -> serializeInstanceName(instanceName))
+        .authorizedUrl();
   }
 
   /**

--- a/src/main/java/bio/terra/cloudres/aws/notebook/SageMakerNotebookOperation.java
+++ b/src/main/java/bio/terra/cloudres/aws/notebook/SageMakerNotebookOperation.java
@@ -5,6 +5,7 @@ import bio.terra.cloudres.common.CloudOperation;
 /** {@link CloudOperation} for using AWS Sagemaker Notebook API. */
 public enum SageMakerNotebookOperation implements CloudOperation {
   AWS_CREATE_NOTEBOOK,
+  AWS_CREATE_PRESIGNED_URL_NOTEBOOK,
   AWS_DELETE_NOTEBOOK,
   AWS_GET_NOTEBOOK,
   AWS_START_NOTEBOOK,

--- a/src/test/java/bio/terra/cloudres/aws/notebook/SageMakerNotebookCowTest.java
+++ b/src/test/java/bio/terra/cloudres/aws/notebook/SageMakerNotebookCowTest.java
@@ -60,8 +60,8 @@ public class SageMakerNotebookCowTest {
     JsonObject serializedRequest = notebookCow.createJsonObjectWithSingleField("request", request);
     assertEquals(json.getAsJsonObject("requestData"), serializedRequest);
     assertEquals(
-        json.get("operation").getAsString(),
-        SageMakerNotebookOperation.AWS_CREATE_NOTEBOOK.toString());
+        SageMakerNotebookOperation.AWS_CREATE_NOTEBOOK.toString(),
+        json.get("operation").getAsString());
   }
 
   @Test
@@ -74,8 +74,8 @@ public class SageMakerNotebookCowTest {
     JsonObject serializedRequest = notebookCow.serializeInstanceName(instanceName);
     assertEquals(json.getAsJsonObject("requestData"), serializedRequest);
     assertEquals(
-        json.get("operation").getAsString(),
-        SageMakerNotebookOperation.AWS_GET_NOTEBOOK.toString());
+        SageMakerNotebookOperation.AWS_GET_NOTEBOOK.toString(),
+        json.get("operation").getAsString());
   }
 
   @Test
@@ -93,8 +93,8 @@ public class SageMakerNotebookCowTest {
     JsonObject serializedRequest = notebookCow.serializeInstanceName(instanceName);
     assertEquals(json.getAsJsonObject("requestData"), serializedRequest);
     assertEquals(
-        json.get("operation").getAsString(),
-        SageMakerNotebookOperation.AWS_CREATE_PRESIGNED_URL_NOTEBOOK.toString());
+        SageMakerNotebookOperation.AWS_CREATE_PRESIGNED_URL_NOTEBOOK.toString(),
+        json.get("operation").getAsString());
   }
 
   @Test
@@ -107,8 +107,8 @@ public class SageMakerNotebookCowTest {
     JsonObject serializedRequest = notebookCow.serializeInstanceName(instanceName);
     assertEquals(json.getAsJsonObject("requestData"), serializedRequest);
     assertEquals(
-        json.get("operation").getAsString(),
-        SageMakerNotebookOperation.AWS_START_NOTEBOOK.toString());
+        SageMakerNotebookOperation.AWS_START_NOTEBOOK.toString(),
+        json.get("operation").getAsString());
   }
 
   @Test
@@ -121,8 +121,8 @@ public class SageMakerNotebookCowTest {
     JsonObject serializedRequest = notebookCow.serializeInstanceName(instanceName);
     assertEquals(json.getAsJsonObject("requestData"), serializedRequest);
     assertEquals(
-        json.get("operation").getAsString(),
-        SageMakerNotebookOperation.AWS_STOP_NOTEBOOK.toString());
+        SageMakerNotebookOperation.AWS_STOP_NOTEBOOK.toString(),
+        json.get("operation").getAsString());
   }
 
   @Test
@@ -135,7 +135,7 @@ public class SageMakerNotebookCowTest {
     JsonObject serializedRequest = notebookCow.serializeInstanceName(instanceName);
     assertEquals(json.getAsJsonObject("requestData"), serializedRequest);
     assertEquals(
-        json.get("operation").getAsString(),
-        SageMakerNotebookOperation.AWS_DELETE_NOTEBOOK.toString());
+        SageMakerNotebookOperation.AWS_DELETE_NOTEBOOK.toString(),
+        json.get("operation").getAsString());
   }
 }

--- a/src/test/java/bio/terra/cloudres/aws/notebook/SageMakerNotebookCowTest.java
+++ b/src/test/java/bio/terra/cloudres/aws/notebook/SageMakerNotebookCowTest.java
@@ -17,6 +17,8 @@ import org.slf4j.Logger;
 import software.amazon.awssdk.services.sagemaker.SageMakerClient;
 import software.amazon.awssdk.services.sagemaker.model.CreateNotebookInstanceRequest;
 import software.amazon.awssdk.services.sagemaker.model.CreateNotebookInstanceResponse;
+import software.amazon.awssdk.services.sagemaker.model.CreatePresignedNotebookInstanceUrlRequest;
+import software.amazon.awssdk.services.sagemaker.model.CreatePresignedNotebookInstanceUrlResponse;
 import software.amazon.awssdk.services.sagemaker.waiters.SageMakerWaiter;
 
 /**
@@ -74,6 +76,25 @@ public class SageMakerNotebookCowTest {
     assertEquals(
         json.get("operation").getAsString(),
         SageMakerNotebookOperation.AWS_GET_NOTEBOOK.toString());
+  }
+
+  @Test
+  public void createPresignedUrlNotebookTest() {
+    ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<JsonObject> gsonArgumentCaptor = ArgumentCaptor.forClass(JsonObject.class);
+    String fakeUrl = "https://example.com";
+    when(mockSageMakerClient.createPresignedNotebookInstanceUrl(
+            (CreatePresignedNotebookInstanceUrlRequest) any()))
+        .thenReturn(
+            CreatePresignedNotebookInstanceUrlResponse.builder().authorizedUrl(fakeUrl).build());
+    assertEquals(fakeUrl, notebookCow.createPresignedUrl(instanceName));
+    verify(mockLogger).debug(stringArgumentCaptor.capture(), gsonArgumentCaptor.capture());
+    JsonObject json = gsonArgumentCaptor.getValue();
+    JsonObject serializedRequest = notebookCow.serializeInstanceName(instanceName);
+    assertEquals(json.getAsJsonObject("requestData"), serializedRequest);
+    assertEquals(
+        json.get("operation").getAsString(),
+        SageMakerNotebookOperation.AWS_CREATE_PRESIGNED_URL_NOTEBOOK.toString());
   }
 
   @Test


### PR DESCRIPTION
Add method to get a presigned URL (equivalent to "proxy link" for Vertex AI instances, but signed rather than IAM-controlled).