### PR TITLE
[PF2868] Add autodelete to test clusters

### DIFF
--- a/src/test/java/bio/terra/cloudres/google/dataproc/DataprocCowTest.java
+++ b/src/test/java/bio/terra/cloudres/google/dataproc/DataprocCowTest.java
@@ -265,7 +265,7 @@ public class DataprocCowTest {
             + reusableNetwork.getSelfLink()
             + "\",\"serviceAccount\":\""
             + dataprocWorkerServiceAccount.getEmail()
-            + "\",\"tags\":[\"dataproc\"]},\"masterConfig\":{\"machineTypeUri\":\"e2-standard-2\",\"numInstances\":1},\"workerConfig\":{\"machineTypeUri\":\"e2-standard-2\",\"numInstances\":2}}}}";
+            + "\",\"tags\":[\"dataproc\"]},\"lifecycleConfig\":{\"autoDeleteTtl\":\"1800s\"},\"masterConfig\":{\"machineTypeUri\":\"e2-standard-2\",\"numInstances\":1},\"workerConfig\":{\"machineTypeUri\":\"e2-standard-2\",\"numInstances\":2}}}}";
     String actual =
         dataproc
             .clusters()

--- a/src/test/java/bio/terra/cloudres/google/dataproc/DataprocCowTest.java
+++ b/src/test/java/bio/terra/cloudres/google/dataproc/DataprocCowTest.java
@@ -24,6 +24,7 @@ import com.google.api.services.dataproc.model.Cluster;
 import com.google.api.services.dataproc.model.ClusterConfig;
 import com.google.api.services.dataproc.model.GceClusterConfig;
 import com.google.api.services.dataproc.model.InstanceGroupConfig;
+import com.google.api.services.dataproc.model.LifecycleConfig;
 import com.google.api.services.dataproc.model.ListClustersResponse;
 import com.google.api.services.dataproc.model.Operation;
 import com.google.api.services.dataproc.model.Policy;
@@ -125,9 +126,10 @@ public class DataprocCowTest {
                     // by dataproc
                     new InstanceGroupConfig().setNumInstances(1).setMachineTypeUri("e2-standard-2"))
                 .setWorkerConfig(
-                    new InstanceGroupConfig()
-                        .setNumInstances(2)
-                        .setMachineTypeUri("e2-standard-2")));
+                    new InstanceGroupConfig().setNumInstances(2).setMachineTypeUri("e2-standard-2"))
+                .setLifecycleConfig(
+                    // 30m. GCP expects the duration in seconds suffixed with "s"
+                    new LifecycleConfig().setAutoDeleteTtl("1800s")));
   }
 
   @Test
@@ -189,6 +191,8 @@ public class DataprocCowTest {
 
     Cluster updatedCluster = dataproc.clusters().get(clusterName).execute();
     assertEquals(updatedCluster.getConfig().getWorkerConfig().getNumInstances(), 3);
+
+    dataproc.clusters().delete(clusterName).execute();
   }
 
   @Test


### PR DESCRIPTION
This configures the test dataproc clusters to automatically delete after 30m. This should help for when tests fail to clean up their clusters. Thanks Roger for thinking of this!

This also adds a `delete` call to the one test which created a cluster but did not delete it.