### PR TITLE
[CORE-117] Fix google billing GSON serialization

### DIFF
--- a/src/main/java/bio/terra/cloudres/google/billing/CloudBillingClientCow.java
+++ b/src/main/java/bio/terra/cloudres/google/billing/CloudBillingClientCow.java
@@ -17,6 +17,8 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static bio.terra.cloudres.util.SerializeHelper.createGson;
+
 /**
  * A Cloud Object Wrapper (COW) for {@link CloudBillingClient}.
  *
@@ -79,7 +81,8 @@ public class CloudBillingClientCow implements AutoCloseable {
   @VisibleForTesting
   static JsonObject serialize(String projectName, ProjectBillingInfo projectBillingInfo) {
     JsonObject result = serializeProjectName(projectName);
-    result.add("project_billing_info", new Gson().toJsonTree(projectBillingInfo));
+    Gson gson = createGson();
+    result.add("project_billing_info", gson.toJsonTree(projectBillingInfo));
     return result;
   }
 

--- a/src/main/java/bio/terra/cloudres/google/billing/CloudBillingClientCow.java
+++ b/src/main/java/bio/terra/cloudres/google/billing/CloudBillingClientCow.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * A Cloud Object Wrapper (COW) for {@link CloudBillingClient}.
  *

--- a/src/main/java/bio/terra/cloudres/google/billing/SerializeBillingUtils.java
+++ b/src/main/java/bio/terra/cloudres/google/billing/SerializeBillingUtils.java
@@ -33,5 +33,4 @@ public class SerializeBillingUtils extends SerializeHelper {
     result.add("permissions", permissions);
     return result;
   }
-
 }

--- a/src/main/java/bio/terra/cloudres/google/billing/SerializeBillingUtils.java
+++ b/src/main/java/bio/terra/cloudres/google/billing/SerializeBillingUtils.java
@@ -1,0 +1,37 @@
+package bio.terra.cloudres.google.billing;
+
+import bio.terra.cloudres.util.SerializeHelper;
+import com.google.cloud.billing.v1.ProjectBillingInfo;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.iam.v1.TestIamPermissionsRequest;
+
+/** Utils for serializing {@link com.google.cloud.storage} objects. */
+public class SerializeBillingUtils extends SerializeHelper {
+
+  private SerializeBillingUtils() {}
+
+  static JsonObject convert(String projectName) {
+    JsonObject result = new JsonObject();
+    result.addProperty("project_name", projectName);
+    return result;
+  }
+
+  static JsonObject convert(String projectName, ProjectBillingInfo projectBillingInfo) {
+    JsonObject result = convert(projectName);
+    Gson gson = createGson();
+    result.add("project_billing_info", gson.toJsonTree(projectBillingInfo));
+    return result;
+  }
+
+  static JsonObject convert(TestIamPermissionsRequest request) {
+    JsonObject result = new JsonObject();
+    result.addProperty("resource", request.getResource());
+    JsonArray permissions = new JsonArray();
+    request.getPermissionsList().forEach(permissions::add);
+    result.add("permissions", permissions);
+    return result;
+  }
+
+}

--- a/src/main/java/bio/terra/cloudres/google/storage/SerializeUtils.java
+++ b/src/main/java/bio/terra/cloudres/google/storage/SerializeUtils.java
@@ -1,21 +1,18 @@
 package bio.terra.cloudres.google.storage;
 
+import bio.terra.cloudres.util.SerializeHelper;
 import bio.terra.janitor.model.CloudResourceUid;
 import bio.terra.janitor.model.GoogleBlobUid;
-import com.fatboyindustrial.gsonjavatime.Converters;
 import com.google.cloud.Policy;
 import com.google.cloud.storage.*;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializer;
-import java.lang.reflect.Type;
-import java.time.Duration;
 
 /** Utils for serializing {@link com.google.cloud.storage} objects. */
-class SerializeUtils {
-  private SerializeUtils() {}
+public class SerializeUtils extends SerializeHelper {
+  private SerializeUtils() {
+    super();
+  }
 
   static CloudResourceUid create(BlobId blobId) {
     return new CloudResourceUid()
@@ -63,20 +60,4 @@ class SerializeUtils {
     return convertWithGson(policy, Policy.class);
   }
 
-  /**
-   * Helper for Gson convertible classes. Should only be used with classes that play nicely with
-   * Gson.
-   */
-  private static <R> JsonObject convertWithGson(R r, Type t) {
-    return createGson().toJsonTree(r, t).getAsJsonObject();
-  }
-
-  private static Gson createGson() {
-    return Converters.registerAll(new GsonBuilder())
-        .registerTypeAdapter(
-            Duration.class,
-            (JsonSerializer<Duration>)
-                (src, typeOfSrc, context) -> new JsonPrimitive(src.toMillis()))
-        .create();
-  }
 }

--- a/src/main/java/bio/terra/cloudres/google/storage/SerializeUtils.java
+++ b/src/main/java/bio/terra/cloudres/google/storage/SerializeUtils.java
@@ -57,5 +57,4 @@ public class SerializeUtils extends SerializeHelper {
   static JsonObject convert(Policy policy) {
     return convertWithGson(policy, Policy.class);
   }
-
 }

--- a/src/main/java/bio/terra/cloudres/google/storage/SerializeUtils.java
+++ b/src/main/java/bio/terra/cloudres/google/storage/SerializeUtils.java
@@ -10,9 +10,7 @@ import com.google.gson.JsonObject;
 
 /** Utils for serializing {@link com.google.cloud.storage} objects. */
 public class SerializeUtils extends SerializeHelper {
-  private SerializeUtils() {
-    super();
-  }
+  private SerializeUtils() {}
 
   static CloudResourceUid create(BlobId blobId) {
     return new CloudResourceUid()

--- a/src/main/java/bio/terra/cloudres/util/SerializeHelper.java
+++ b/src/main/java/bio/terra/cloudres/util/SerializeHelper.java
@@ -2,7 +2,6 @@ package bio.terra.cloudres.util;
 
 import com.fatboyindustrial.gsonjavatime.Converters;
 import com.google.gson.*;
-
 import java.lang.reflect.Type;
 import java.time.Duration;
 

--- a/src/main/java/bio/terra/cloudres/util/SerializeHelper.java
+++ b/src/main/java/bio/terra/cloudres/util/SerializeHelper.java
@@ -1,0 +1,29 @@
+package bio.terra.cloudres.util;
+
+import com.fatboyindustrial.gsonjavatime.Converters;
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+import java.time.Duration;
+
+/** Utils for serializing {@link com.google.cloud} objects. */
+public class SerializeHelper {
+  public SerializeHelper() {}
+
+  /**
+   * Helper for Gson convertible classes. Should only be used with classes that play nicely with
+   * Gson.
+   */
+  public static <R> JsonObject convertWithGson(R r, Type t) {
+    return createGson().toJsonTree(r, t).getAsJsonObject();
+  }
+
+  public static Gson createGson() {
+    return Converters.registerAll(new GsonBuilder())
+        .registerTypeAdapter(
+            Duration.class,
+            (JsonSerializer<Duration>)
+                (src, typeOfSrc, context) -> new JsonPrimitive(src.toMillis()))
+        .create();
+  }
+}

--- a/src/test/java/bio/terra/cloudres/google/billing/CloudBillingClientCowTest.java
+++ b/src/test/java/bio/terra/cloudres/google/billing/CloudBillingClientCowTest.java
@@ -71,7 +71,7 @@ public class CloudBillingClientCowTest {
   public void serializeProjectName() {
     assertEquals(
         "{\"project_name\":\"projects/my-project\"}",
-            SerializeBillingUtils.convert("projects/my-project").toString());
+        SerializeBillingUtils.convert("projects/my-project").toString());
   }
 
   @Test
@@ -82,7 +82,7 @@ public class CloudBillingClientCowTest {
             + "\"billingAccountName_\":\"billingAccounts/01A82E-CA8A14-367457\",\"billingEnabled_\":false,"
             + "\"memoizedIsInitialized\":1,\"unknownFields\":{\"fields\":{}},"
             + "\"memoizedSize\":-1,\"memoizedHashCode\":0}}",
-            SerializeBillingUtils.convert(
+        SerializeBillingUtils.convert(
                 "projects/my-project",
                 ProjectBillingInfo.newBuilder()
                     .setProjectId("my-project")
@@ -96,7 +96,7 @@ public class CloudBillingClientCowTest {
     assertEquals(
         "{\"resource\":\"billingAccounts/01A82E-CA8A14-367457\","
             + "\"permissions\":[\"billing.resourceAssociations.create\"]}",
-            SerializeBillingUtils.convert(
+        SerializeBillingUtils.convert(
                 TestIamPermissionsRequest.newBuilder()
                     .setResource("billingAccounts/01A82E-CA8A14-367457")
                     .addPermissions("billing.resourceAssociations.create")

--- a/src/test/java/bio/terra/cloudres/google/billing/CloudBillingClientCowTest.java
+++ b/src/test/java/bio/terra/cloudres/google/billing/CloudBillingClientCowTest.java
@@ -71,7 +71,7 @@ public class CloudBillingClientCowTest {
   public void serializeProjectName() {
     assertEquals(
         "{\"project_name\":\"projects/my-project\"}",
-        CloudBillingClientCow.serializeProjectName("projects/my-project").toString());
+            SerializeBillingUtils.convert("projects/my-project").toString());
   }
 
   @Test
@@ -82,7 +82,7 @@ public class CloudBillingClientCowTest {
             + "\"billingAccountName_\":\"billingAccounts/01A82E-CA8A14-367457\",\"billingEnabled_\":false,"
             + "\"memoizedIsInitialized\":1,\"unknownFields\":{\"fields\":{}},"
             + "\"memoizedSize\":-1,\"memoizedHashCode\":0}}",
-        CloudBillingClientCow.serialize(
+            SerializeBillingUtils.convert(
                 "projects/my-project",
                 ProjectBillingInfo.newBuilder()
                     .setProjectId("my-project")
@@ -96,7 +96,7 @@ public class CloudBillingClientCowTest {
     assertEquals(
         "{\"resource\":\"billingAccounts/01A82E-CA8A14-367457\","
             + "\"permissions\":[\"billing.resourceAssociations.create\"]}",
-        CloudBillingClientCow.serializeTestIamPermissions(
+            SerializeBillingUtils.convert(
                 TestIamPermissionsRequest.newBuilder()
                     .setResource("billingAccounts/01A82E-CA8A14-367457")
                     .addPermissions("billing.resourceAssociations.create")


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-117

**Context:**
When attempting to update RBS to the latest terra-common-lib, the tests failed because gson cannot serialize the project billing info:
```
com.google.gson.JsonIOException: Failed making field 'java.lang.ref.Reference#referent' accessible; either increase its visibility or write a custom TypeAdapter for its declaring type. See https://github.com/google/gson/blob/main/Troubleshooting.md#reflection-inaccessible
```

**Changes:**
Use the custom type adapter added in https://github.com/DataBiosphere/terra-cloud-resource-lib/pull/179