### PR TITLE
[CORE-117] Do not use gson to serialize ProjectBillingInfo

### DIFF
--- a/src/main/java/bio/terra/cloudres/google/billing/SerializeBillingUtils.java
+++ b/src/main/java/bio/terra/cloudres/google/billing/SerializeBillingUtils.java
@@ -2,7 +2,6 @@ package bio.terra.cloudres.google.billing;
 
 import bio.terra.cloudres.util.SerializeHelper;
 import com.google.cloud.billing.v1.ProjectBillingInfo;
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.iam.v1.TestIamPermissionsRequest;

--- a/src/main/java/bio/terra/cloudres/google/billing/SerializeBillingUtils.java
+++ b/src/main/java/bio/terra/cloudres/google/billing/SerializeBillingUtils.java
@@ -20,8 +20,12 @@ public class SerializeBillingUtils extends SerializeHelper {
 
   static JsonObject convert(String projectName, ProjectBillingInfo projectBillingInfo) {
     JsonObject result = convert(projectName);
-    Gson gson = createGson();
-    result.add("project_billing_info", gson.toJsonTree(projectBillingInfo));
+    JsonObject billingInfo = new JsonObject();
+    billingInfo.addProperty("name_", projectName);
+    billingInfo.addProperty("projectId_", projectBillingInfo.getProjectId());
+    billingInfo.addProperty("billingAccountName_", projectBillingInfo.getBillingAccountName());
+    billingInfo.addProperty("billingEnabled_", projectBillingInfo.getBillingEnabled());
+    result.add("project_billing_info", billingInfo);
     return result;
   }
 

--- a/src/test/java/bio/terra/cloudres/google/billing/CloudBillingClientCowTest.java
+++ b/src/test/java/bio/terra/cloudres/google/billing/CloudBillingClientCowTest.java
@@ -78,10 +78,8 @@ public class CloudBillingClientCowTest {
   public void serialize() {
     assertEquals(
         "{\"project_name\":\"projects/my-project\","
-            + "\"project_billing_info\":{\"name_\":\"\",\"projectId_\":\"my-project\","
-            + "\"billingAccountName_\":\"billingAccounts/01A82E-CA8A14-367457\",\"billingEnabled_\":false,"
-            + "\"memoizedIsInitialized\":1,\"unknownFields\":{\"fields\":{}},"
-            + "\"memoizedSize\":-1,\"memoizedHashCode\":0}}",
+            + "\"project_billing_info\":{\"name_\":\"projects/my-project\",\"projectId_\":\"my-project\","
+            + "\"billingAccountName_\":\"billingAccounts/01A82E-CA8A14-367457\",\"billingEnabled_\":false}}",
         SerializeBillingUtils.convert(
                 "projects/my-project",
                 ProjectBillingInfo.newBuilder()


### PR DESCRIPTION
Explicitly define each field in the project billing info JSON object instead of relying on GSON for serialization.