### PR TITLE
[CORE-593] Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ out/
 ### Mac directory metadata
 .DS_Store
 
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json
+
 ### Jenv directory-local version setting
 .java-version
 


### PR DESCRIPTION
In order to complete https://broadworkbench.atlassian.net/browse/CORE-593, service account auth will need to be added.  Preemptively updating .gitignore to avoid committing any creds.  Actual PR for CORE-593 will come later

